### PR TITLE
[FEAT] 프로젝트 목록 페이지 완성

### DIFF
--- a/src/main/java/com/animalfarm/mlf/constants/ProjectStatus.java
+++ b/src/main/java/com/animalfarm/mlf/constants/ProjectStatus.java
@@ -1,0 +1,20 @@
+package com.animalfarm.mlf.constants;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ProjectStatus {
+	PREPARING("준비중", "preparing", "others"),
+	ANNOUNCEMENT("공고중", "announcement", "bg-info"),
+	SUBSCRIPTION("청약중", "subscription", "bg-warning"),
+	INPROGRESS("진행중", "inProgress", "bg-primary"),
+	CANCELLED("취소됨", "canceled", "others"),
+	COMPLETED("종료됨", "completed", "others");
+
+	private final String label;
+	private final String badgeStatus;
+	private final String btnClass;
+
+}

--- a/src/main/java/com/animalfarm/mlf/domain/project/ProjectController.java
+++ b/src/main/java/com/animalfarm/mlf/domain/project/ProjectController.java
@@ -74,6 +74,7 @@ public class ProjectController {
 		}
 		return message;
 	}
+	
 	@PostMapping("/api/projects/insert")
 	public ResponseEntity<String> insertProject(@RequestBody
 	ProjectInsertDTO projectInsertDTO) {

--- a/src/main/java/com/animalfarm/mlf/domain/project/ProjectController.java
+++ b/src/main/java/com/animalfarm/mlf/domain/project/ProjectController.java
@@ -62,19 +62,24 @@ public class ProjectController {
 		return projectService.selectByCondition(searchDTO);
 	}
 
-	//관심 프로젝트 신규 등록
-	@PostMapping("/api/projects/starred/interest")
-	public String upsertStrarredProject(@ModelAttribute
+	//관심 프로젝트인지 조회
+	@GetMapping("/api/projects/starred")
+	public boolean getStarredStatus(@ModelAttribute
 	ProjectStarredDTO projectStarredDTO) {
-		String message = null;
-		if (projectService.upsertStrarredProject(projectStarredDTO)) {
-			message = "success";
-		} else {
-			message = "fail";
-		}
-		return message;
+		return projectService.getStarredStatus(projectStarredDTO);
 	}
-	
+
+	//관심 프로젝트 신규 등록
+	@PostMapping("/api/projects/starred")
+	public Boolean upsertStrarredProject(@RequestBody
+	ProjectStarredDTO projectStarredDTO) {
+		Boolean curStatus = null;
+		if (projectService.upsertStrarredProject(projectStarredDTO)) {
+			curStatus = projectService.getStarredStatus(projectStarredDTO);
+		}
+		return curStatus;
+	}
+
 	@PostMapping("/api/projects/insert")
 	public ResponseEntity<String> insertProject(@RequestBody
 	ProjectInsertDTO projectInsertDTO) {

--- a/src/main/java/com/animalfarm/mlf/domain/project/ProjectRepository.java
+++ b/src/main/java/com/animalfarm/mlf/domain/project/ProjectRepository.java
@@ -21,9 +21,11 @@ public interface ProjectRepository {
 	public abstract List<ProjectListDTO> selectByCondition(ProjectSearchReqDTO projectSearchDTO);
 
 	public abstract ProjectDetailDTO selectDetail(Long projectId);
-	
+
 	public abstract boolean selectStarredProject(ProjectStarredDTO projectStarredDTO);
-	
+
+	public abstract boolean getStarredStatus(ProjectStarredDTO projectStarredDTO);
+
 	public abstract void insertStrarredProject(ProjectStarredDTO projectStarredDTO);
 
 	public abstract void updateStarred(ProjectStarredDTO projectStarredDTO);

--- a/src/main/java/com/animalfarm/mlf/domain/project/ProjectService.java
+++ b/src/main/java/com/animalfarm/mlf/domain/project/ProjectService.java
@@ -37,11 +37,15 @@ public class ProjectService {
 		return projectRepository.selectByCondition(searchDTO);
 	}
 
+	public boolean getStarredStatus(ProjectStarredDTO projectStarredDTO) {
+		return projectRepository.getStarredStatus(projectStarredDTO);
+	}
+
 	//select하여 있다면 관심 프로젝트 등록/해제 없다면 관심 프로젝트 신규 생성
 	public boolean upsertStrarredProject(ProjectStarredDTO projectStarredDTO) {
 		try {
 			boolean isExist = projectRepository.selectStarredProject(projectStarredDTO);
-			if(isExist) {
+			if (isExist) {
 				projectRepository.updateStarred(projectStarredDTO);
 				return true;
 			} else {
@@ -53,6 +57,7 @@ public class ProjectService {
 			return false;
 		}
 	}
+
 	@Transactional
 	public boolean insertProject(ProjectInsertDTO projectInsertDTO) {
 		try {

--- a/src/main/java/com/animalfarm/mlf/domain/project/ProjectViewController.java
+++ b/src/main/java/com/animalfarm/mlf/domain/project/ProjectViewController.java
@@ -1,13 +1,19 @@
 package com.animalfarm.mlf.domain.project;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import com.animalfarm.mlf.domain.project.dto.ProjectSearchReqDTO;
+
 @Controller
 @RequestMapping("/project")
 public class ProjectViewController {
+
+	@Autowired
+	ProjectService projectService;
 
 	@GetMapping({"", "/"})
 	public String index() {
@@ -15,9 +21,10 @@ public class ProjectViewController {
 	}
 
 	@GetMapping("/list")
-	public String projectListPage(Model model) {
+	public String projectListPage(Model model, ProjectSearchReqDTO searchReqDTO) {
 		model.addAttribute("contentPage", "/WEB-INF/views/project/project_list.jsp");
 		model.addAttribute("activeMenu", "project");
+		model.addAttribute("projectList", projectService.selectByCondition(searchReqDTO));
 		return "layout"; // 항상 layout.jsp를 리턴
 	}
 }

--- a/src/main/java/com/animalfarm/mlf/domain/project/ProjectViewController.java
+++ b/src/main/java/com/animalfarm/mlf/domain/project/ProjectViewController.java
@@ -1,0 +1,23 @@
+package com.animalfarm.mlf.domain.project;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/project")
+public class ProjectViewController {
+
+	@GetMapping({"", "/"})
+	public String index() {
+		return "redirect:/project/list";
+	}
+
+	@GetMapping("/list")
+	public String projectListPage(Model model) {
+		model.addAttribute("contentPage", "/WEB-INF/views/project/project_list.jsp");
+		model.addAttribute("activeMenu", "project");
+		return "layout"; // 항상 layout.jsp를 리턴
+	}
+}

--- a/src/main/java/com/animalfarm/mlf/domain/project/ProjectViewController.java
+++ b/src/main/java/com/animalfarm/mlf/domain/project/ProjectViewController.java
@@ -27,4 +27,11 @@ public class ProjectViewController {
 		model.addAttribute("projectList", projectService.selectByCondition(searchReqDTO));
 		return "layout"; // 항상 layout.jsp를 리턴
 	}
+
+	@GetMapping("/list/fragment")
+	public String projectListFragment(Model model, ProjectSearchReqDTO searchReqDTO) {
+		System.out.println(searchReqDTO);
+		model.addAttribute("projectList", projectService.selectByCondition(searchReqDTO));
+		return "project/project_card_list";
+	}
 }

--- a/src/main/resources/mybatis/mappers/ProjectMapper.xml
+++ b/src/main/resources/mybatis/mappers/ProjectMapper.xml
@@ -215,6 +215,12 @@
     		 #{projectPictureId}
    		</foreach>
     </delete>
+    
+    <select id="getStarredStatus" parameterType="ProjectStarredDTO" resultType="boolean">
+    	select is_starred
+    	from starred_projects
+    	where user_id = #{userId} and project_id = #{projectId}
+    </select>
 	
 	<!-- 관심프로젝트 추가 -->
 	<insert id="insertStrarredProject"

--- a/src/main/webapp/WEB-INF/tags/icon.tag
+++ b/src/main/webapp/WEB-INF/tags/icon.tag
@@ -10,8 +10,14 @@
 
 <c:choose>
     
+    <c:when test="${name == 'heart_filled'}">
+	    <svg width="${size}" height="${size}" class="${className}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640">
+	    <!--!Font Awesome Free v7.1.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.-->
+	    <path fill="${color}" d="M305 151.1L320 171.8L335 151.1C360 116.5 400.2 96 442.9 96C516.4 96 576 155.6 576 229.1L576 231.7C576 343.9 436.1 474.2 363.1 529.9C350.7 539.3 335.5 544 320 544C304.5 544 289.2 539.4 276.9 529.9C203.9 474.2 64 343.9 64 231.7L64 229.1C64 155.6 123.6 96 197.1 96C239.8 96 280 116.5 305 151.1z"/>
+	    </svg>
+    </c:when>
     <c:when test="${name == 'leaf'}">
-      <svg width="${size}" height="${size}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640">
+      <svg width="${size}" height="${size}" class="${className}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640">
         <!--!Font Awesome Free v7.1.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.-->
         <path fill="${color}" 
           d="M535.3 70.7C541.7 64.6 551 62.4 559.6 65.2C569.4 68.5 576 77.7 576 88L576 274.9C576 406.1 467.9 512 337.2 512C260.2 512 193.8 462.5 169.7 393.3C134.3 424.1 112 469.4 112 520C112 533.3 101.3 544 88 544C74.7 544 64 533.3 64 520C64 445.1 102.2 379.1 160.1 340.3C195.4 316.7 237.5 304 280 304L360 304C373.3 304 384 293.3 384 280C384 266.7 373.3 256 360 256L280 256C240.3 256 202.7 264.8 169 280.5C192.3 210.5 258.2 160 336 160C402.4 160 451.8 137.9 484.7 116C503.9 103.2 520.2 87.9 535.4 70.7z"/>

--- a/src/main/webapp/WEB-INF/tags/icon.tag
+++ b/src/main/webapp/WEB-INF/tags/icon.tag
@@ -36,6 +36,19 @@
     <c:when test="${name == 'youtube'}">
     	<svg  width="${size}" height="${size}" class="${className}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640">
     		<!--!Font Awesome Free v7.1.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.-->
-    		<path fill="${color}" d="M581.7 188.1C575.5 164.4 556.9 145.8 533.4 139.5C490.9 128 320.1 128 320.1 128C320.1 128 149.3 128 106.7 139.5C83.2 145.8 64.7 164.4 58.4 188.1C47 231 47 320.4 47 320.4C47 320.4 47 409.8 58.4 452.7C64.7 476.3 83.2 494.2 106.7 500.5C149.3 512 320.1 512 320.1 512C320.1 512 490.9 512 533.5 500.5C557 494.2 575.5 476.3 581.8 452.7C593.2 409.8 593.2 320.4 593.2 320.4C593.2 320.4 593.2 231 581.8 188.1zM264.2 401.6L264.2 239.2L406.9 320.4L264.2 401.6z"/></svg>
+    		<path fill="${color}" d="M581.7 188.1C575.5 164.4 556.9 145.8 533.4 139.5C490.9 128 320.1 128 320.1 128C320.1 128 149.3 128 106.7 139.5C83.2 145.8 64.7 164.4 58.4 188.1C47 231 47 320.4 47 320.4C47 320.4 47 409.8 58.4 452.7C64.7 476.3 83.2 494.2 106.7 500.5C149.3 512 320.1 512 320.1 512C320.1 512 490.9 512 533.5 500.5C557 494.2 575.5 476.3 581.8 452.7C593.2 409.8 593.2 320.4 593.2 320.4C593.2 320.4 593.2 231 581.8 188.1zM264.2 401.6L264.2 239.2L406.9 320.4L264.2 401.6z"/>
+   		</svg>
+    </c:when>
+    <c:when test="${ name=='seedling' }">
+    	<svg width="${size}" height="${size}" class="${className}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640">
+    	<!--!Font Awesome Free v7.1.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.-->
+    		<path fill="${color}" d="M576 96C576 204.1 499.4 294.3 397.6 315.4C389.7 257.3 363.6 205 325.1 164.5C365.2 104 433.9 64 512 64L544 64C561.7 64 576 78.3 576 96zM64 160C64 142.3 78.3 128 96 128L128 128C251.7 128 352 228.3 352 352L352 544C352 561.7 337.7 576 320 576C302.3 576 288 561.7 288 544L288 384C164.3 384 64 283.7 64 160z"/>
+   		</svg>
+    </c:when>
+    <c:when test="${name=='search' }">
+	    <svg  width="${size}" height="${size}" class="${className}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640">
+	    <!--!Font Awesome Free v7.1.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.-->
+	    	<path fill="${color}" d="M480 272C480 317.9 465.1 360.3 440 394.7L566.6 521.4C579.1 533.9 579.1 554.2 566.6 566.7C554.1 579.2 533.8 579.2 521.3 566.7L394.7 440C360.3 465.1 317.9 480 272 480C157.1 480 64 386.9 64 272C64 157.1 157.1 64 272 64C386.9 64 480 157.1 480 272zM272 416C351.5 416 416 351.5 416 272C416 192.5 351.5 128 272 128C192.5 128 128 192.5 128 272C128 351.5 192.5 416 272 416z"/>
+    	</svg>
     </c:when>
 </c:choose>

--- a/src/main/webapp/WEB-INF/tags/menu_button.tag
+++ b/src/main/webapp/WEB-INF/tags/menu_button.tag
@@ -1,8 +1,9 @@
 <%@ tag language="java" pageEncoding="UTF-8" body-content="empty" %>
 <%@ attribute name="label" required="true" %>
 <%@ attribute name="active" required="false" type="java.lang.Boolean" %>
+<%@ attribute name="onClick" required="false" %>
 
-<button class="menu-btn ${active ? 'active' : ''}">
+<button class="menu-btn ${active ? 'active' : ''}" onClick="${onClick}">
     ${label}
 </button>
 

--- a/src/main/webapp/WEB-INF/tags/menu_button.tag
+++ b/src/main/webapp/WEB-INF/tags/menu_button.tag
@@ -1,0 +1,28 @@
+<%@ tag language="java" pageEncoding="UTF-8" body-content="empty" %>
+<%@ attribute name="label" required="true" %>
+<%@ attribute name="active" required="false" type="java.lang.Boolean" %>
+
+<button class="menu-btn ${active ? 'active' : ''}">
+    ${label}
+</button>
+
+<style>
+.menu-btn {
+    padding: 8px 12px;
+    border-radius: var(--radius-m);
+    background-color:transparent;
+    font: var(--font-button-02);
+    color: var(--gray-500);
+    cursor: pointer;
+    transition: all 0.2s;
+    border:none;
+}
+.menu-btn.active {
+    background: var(--green-600);
+    color: white;
+}
+.menu-btn:hover:not(.active) {
+    background: var(--green-0);
+    color: var(--green-600);
+}
+</style>

--- a/src/main/webapp/WEB-INF/tags/project_card.tag
+++ b/src/main/webapp/WEB-INF/tags/project_card.tag
@@ -3,6 +3,8 @@
 <%@ taglib prefix="t" tagdir="/WEB-INF/tags" %>
 <%@ attribute name="status" type="com.animalfarm.mlf.constants.ProjectStatus" required="true" %> <%-- 청약중, 공고중, 진행중 --%>
 <%@ attribute name="title" required="true" %>
+<%@ attribute name="id" required="true"%>
+<%@ attribute name="endTime" required="true" %>
 <%@ attribute name="upperDate" required="true" %>
 <%@ attribute name="lowerDate" required="true" %>
 <%@ attribute name="percent" required="false" %>
@@ -26,10 +28,10 @@
 		            <span class="card-date">${upperDate}</span>
 		            <c:choose>
 		            <c:when test="${status.name() == 'SUBSCRIPTION'}">
-		                <span class="card-dday text-error">마감까지 46:07:20</span>
+		                <span class="card-dday text-error timer-display" data-end-time="${endTime}" data-status="${status.name()}" >마감까지</span>
 		            </c:when>
 		            <c:when test="${status.name() == 'ANNOUNCEMENT'}">
-		                <span class="card-dday text-error">D-5</span>
+		                <span class="card-dday text-error timer-display" data-end-time="${endTime}" data-status="${status.name()}" >시작까지</span>
 		            </c:when>
 		            </c:choose>
 	        	</div>
@@ -61,9 +63,9 @@
             <%-- 버튼 클래스도 Enum에서 가져옴 --%>
             <button class="btn-action ${status.btnClass}">
                 <c:choose>
-                    <c:when test="${status.name() == 'SUBSCRIPTION'}">청약하기</c:when>
-                    <c:when test="${status.name() == 'ANNOUNCEMENT'}">공고보기</c:when>
-                    <c:otherwise>토큰구매</c:otherwise>
+                    <c:when test="${status.name() == 'SUBSCRIPTION'}">청약 하기</c:when>
+                    <c:when test="${status.name() == 'ANNOUNCEMENT'}">공고 보기</c:when>
+                    <c:otherwise>토큰 구매</c:otherwise>
                 </c:choose>
             </button>
         </div>
@@ -71,7 +73,7 @@
 </div>
 
 <style>
-.project-card { background: white; border-radius: var(--radius-l); overflow: hidden; box-shadow: 0 4px 12px rgba(0,0,0,0.05); margin-bottom: 24px; }
+.project-card { background: white; border-radius: var(--radius-l); overflow: hidden; box-shadow: 0 4px 12px rgba(0,0,0,0.05); margin-bottom: 24px; cursor:pointer; }
 .card-image { height: 200px; background: #e5e5e5; position: relative; }
 .badge { position: absolute; top: 16px; left: 16px;}
 .interest-btn {position: absolute; top: 18px; right: 16px; border:none; background-color: transparent; cursor:pointer;} 

--- a/src/main/webapp/WEB-INF/tags/project_card.tag
+++ b/src/main/webapp/WEB-INF/tags/project_card.tag
@@ -1,0 +1,97 @@
+<%@ tag language="java" pageEncoding="UTF-8" body-content="scriptless" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="t" tagdir="/WEB-INF/tags" %>
+<%@ attribute name="status" required="true" %> <%-- 청약중, 공고중, 진행중 --%>
+<%@ attribute name="title" required="true" %>
+<%@ attribute name="date" required="true" %>
+<%@ attribute name="percent" required="false" %>
+
+<c:set var="contentGap" value="${status == '청약중' ? '24px' : (status == '공고중' ? '20px' : '32px')}" />
+<div class="project-card">
+    <div class="card-image">
+        <t:status_badge className="badge" label="${status}" status="${status == '청약중' ? 'onSubscription' : (status == '공고중' ? 'onNotifying' : 'inProgress')}"/>
+        <button class="interest-btn">
+        	<t:icon name="seedling"/>
+        </button>
+    </div>
+    
+    <div class="card-content" style="gap:${contentGap};">
+        <div class="card-info">
+        	<h4 class="card-title">${title}</h4>
+        	<c:if test="${status != '진행중'}"> 
+	        	<div class="card-info-row">
+		            <span class="card-date">${date}</span>
+		            <c:choose>
+		            <c:when test="${status == '청약중'}">
+		                <span class="card-dday text-error">마감까지 46:07:20</span>
+		            </c:when>
+		            <c:when test="${status == '공고중'}">
+		                <span class="card-dday text-error">D-5</span>
+		            </c:when>
+		            </c:choose>
+	        	</div>
+        	</c:if>
+        </div>
+
+        <div class="card-details">
+            <c:choose>
+                <c:when test="${status == '청약중'}">
+                    <div class="progress-container">
+                    	<div class="progress-text"> 
+	                        <div class="progress-percent">${percent}%</div>
+	                        <div class="progress-percent-text">모집</div>
+                    	</div>
+                        <div class="progress-bar"><div class="bar" style="width: ${percent}%"></div></div>
+                    </div>
+                </c:when>
+                <c:when test="${status == '공고중'}">
+                    <div class="info-list">
+                        <p><span>청약 예정일</span><strong>2026-02-01 ~ 02-02</strong></p>
+                        <p><span>예상 수익률</span><strong>연 14.2%</strong></p>
+                    </div>
+                </c:when>
+                <c:otherwise>
+                    <div class="info-list">
+                        <p><span>운영 기간</span><strong>2026-08-03 ~ 2031-08-02</strong></p>
+                        <p><span>현재 수익률</span><strong>연 14.2%</strong></p>
+                    </div>
+                </c:otherwise>
+            </c:choose>
+		</div>
+        <div class="card-buttons">
+            <c:choose>
+                <c:when test="${status == '청약중'}">
+                    <button class="btn-action bg-gray-900">청약하기</button>
+                </c:when>
+                <c:when test="${status == '공고중'}">
+                    <button class="btn-action bg-info">공고보기</button>
+                </c:when>
+                <c:otherwise>
+                    <button class="btn-action bg-success">토큰구매</button>
+                </c:otherwise>
+            </c:choose>
+        </div>
+    </div>
+</div>
+
+<style>
+.project-card { background: white; border-radius: var(--radius-l); overflow: hidden; box-shadow: 0 4px 12px rgba(0,0,0,0.05); margin-bottom: 24px; }
+.card-image { height: 200px; background: #e5e5e5; position: relative; }
+.badge { position: absolute; top: 16px; left: 16px;}
+.interest-btn {position: absolute; top: 18px; right: 16px; border:none; background-color: transparent;} 
+.card-content { display: flex; flex-direction:column; padding: 24px; }
+.card-title { font: var(--font-subtitle-01); color: var(--gray-900);}
+.card-info { display:flex; flex-direction:column; gap:4px}
+.card-info-row { display: flex; justify-content: space-between; font: var(--font-caption-01); color: var(--gray-400); }
+.card-date { font: var(--font-caption-01); }
+.card-dday { font: var(--font-button-02); }
+.progress-text { display:flex; gap:4px; align-items: end; color: var(--green-600) }
+.progress-percent { font:var(--font-body-03); }
+.progress-percent-text { font:var(--font-button-02); }
+.progress-bar { height: 6px; background: var(--gray-100); border-radius: 3px; margin-top: 4px; margin-bottom: 4px; }
+.bar { height: 100%; background: var(--green-600); border-radius: 3px; }
+.info-list {display:flex; flex-direction:column; gap:4px;}
+.info-list p { display: flex; justify-content: space-between; font: var(--font-caption-01); }
+.btn-action { width: 100%; padding: 12px; border: none; border-radius: var(--radius-s); color: white; font: var(--font-button-01); cursor: pointer; }
+.bg-warning { background: var(--warning); } .bg-info { background: var(--info); } .bg-success { background: var(--success); } .bg-gray-900 { background: var(--gray-900); }
+</style>

--- a/src/main/webapp/WEB-INF/tags/project_card.tag
+++ b/src/main/webapp/WEB-INF/tags/project_card.tag
@@ -1,15 +1,18 @@
 <%@ tag language="java" pageEncoding="UTF-8" body-content="scriptless" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="t" tagdir="/WEB-INF/tags" %>
-<%@ attribute name="status" required="true" %> <%-- 청약중, 공고중, 진행중 --%>
+<%@ attribute name="status" type="com.animalfarm.mlf.constants.ProjectStatus" required="true" %> <%-- 청약중, 공고중, 진행중 --%>
 <%@ attribute name="title" required="true" %>
-<%@ attribute name="date" required="true" %>
+<%@ attribute name="upperDate" required="true" %>
+<%@ attribute name="lowerDate" required="true" %>
 <%@ attribute name="percent" required="false" %>
 
-<c:set var="contentGap" value="${status == '청약중' ? '24px' : (status == '공고중' ? '20px' : '32px')}" />
+<c:set var="label" value="${status.label}" />
+<c:set var="contentGap" value="${status.name() == 'SUBSCRIPTION' ? '24px' : (status.name() == 'ANNOUNCEMENT' ? '20px' : '32px')}" />
+
 <div class="project-card">
     <div class="card-image">
-        <t:status_badge className="badge" label="${status}" status="${status == '청약중' ? 'onSubscription' : (status == '공고중' ? 'onNotifying' : 'inProgress')}"/>
+        <t:status_badge className="badge" label="${label}" status="${status.badgeStatus}"/>
         <button class="interest-btn">
         	<t:icon name="seedling"/>
         </button>
@@ -18,14 +21,14 @@
     <div class="card-content" style="gap:${contentGap};">
         <div class="card-info">
         	<h4 class="card-title">${title}</h4>
-        	<c:if test="${status != '진행중'}"> 
+        	<c:if test="${status.name() != 'INPROGRESS'}"> 
 	        	<div class="card-info-row">
-		            <span class="card-date">${date}</span>
+		            <span class="card-date">${upperDate}</span>
 		            <c:choose>
-		            <c:when test="${status == '청약중'}">
+		            <c:when test="${status.name() == 'SUBSCRIPTION'}">
 		                <span class="card-dday text-error">마감까지 46:07:20</span>
 		            </c:when>
-		            <c:when test="${status == '공고중'}">
+		            <c:when test="${status.name() == 'ANNOUNCEMENT'}">
 		                <span class="card-dday text-error">D-5</span>
 		            </c:when>
 		            </c:choose>
@@ -35,7 +38,7 @@
 
         <div class="card-details">
             <c:choose>
-                <c:when test="${status == '청약중'}">
+                <c:when test="${status.name() == 'SUBSCRIPTION'}">
                     <div class="progress-container">
                     	<div class="progress-text"> 
 	                        <div class="progress-percent">${percent}%</div>
@@ -44,32 +47,25 @@
                         <div class="progress-bar"><div class="bar" style="width: ${percent}%"></div></div>
                     </div>
                 </c:when>
-                <c:when test="${status == '공고중'}">
-                    <div class="info-list">
-                        <p><span>청약 예정일</span><strong>2026-02-01 ~ 02-02</strong></p>
-                        <p><span>예상 수익률</span><strong>연 14.2%</strong></p>
-                    </div>
-                </c:when>
                 <c:otherwise>
                     <div class="info-list">
-                        <p><span>운영 기간</span><strong>2026-08-03 ~ 2031-08-02</strong></p>
-                        <p><span>현재 수익률</span><strong>연 14.2%</strong></p>
+                        <p><span>${status.name() == 'ANNOUNCEMENT' ? '청약 예정일' : '운영 기간'}</span>
+                           <strong>${lowerDate}</strong></p>
+                        <p><span>${status.name() == 'ANNOUNCEMENT' ? '예상 수익률' : '현재 수익률'}</span>
+                           <strong>연 14.2%</strong></p>
                     </div>
                 </c:otherwise>
             </c:choose>
 		</div>
         <div class="card-buttons">
-            <c:choose>
-                <c:when test="${status == '청약중'}">
-                    <button class="btn-action bg-gray-900">청약하기</button>
-                </c:when>
-                <c:when test="${status == '공고중'}">
-                    <button class="btn-action bg-info">공고보기</button>
-                </c:when>
-                <c:otherwise>
-                    <button class="btn-action bg-success">토큰구매</button>
-                </c:otherwise>
-            </c:choose>
+            <%-- 버튼 클래스도 Enum에서 가져옴 --%>
+            <button class="btn-action ${status.btnClass}">
+                <c:choose>
+                    <c:when test="${status.name() == 'SUBSCRIPTION'}">청약하기</c:when>
+                    <c:when test="${status.name() == 'ANNOUNCEMENT'}">공고보기</c:when>
+                    <c:otherwise>토큰구매</c:otherwise>
+                </c:choose>
+            </button>
         </div>
     </div>
 </div>
@@ -78,7 +74,7 @@
 .project-card { background: white; border-radius: var(--radius-l); overflow: hidden; box-shadow: 0 4px 12px rgba(0,0,0,0.05); margin-bottom: 24px; }
 .card-image { height: 200px; background: #e5e5e5; position: relative; }
 .badge { position: absolute; top: 16px; left: 16px;}
-.interest-btn {position: absolute; top: 18px; right: 16px; border:none; background-color: transparent;} 
+.interest-btn {position: absolute; top: 18px; right: 16px; border:none; background-color: transparent; cursor:pointer;} 
 .card-content { display: flex; flex-direction:column; padding: 24px; }
 .card-title { font: var(--font-subtitle-01); color: var(--gray-900);}
 .card-info { display:flex; flex-direction:column; gap:4px}
@@ -92,6 +88,8 @@
 .bar { height: 100%; background: var(--green-600); border-radius: 3px; }
 .info-list {display:flex; flex-direction:column; gap:4px;}
 .info-list p { display: flex; justify-content: space-between; font: var(--font-caption-01); }
-.btn-action { width: 100%; padding: 12px; border: none; border-radius: var(--radius-s); color: white; font: var(--font-button-01); cursor: pointer; }
-.bg-warning { background: var(--warning); } .bg-info { background: var(--info); } .bg-success { background: var(--success); } .bg-gray-900 { background: var(--gray-900); }
+.btn-action { width: 100%; padding: 12px; border: none; border-radius: var(--radius-s); background-color:var(--gray-900); color: white; font: var(--font-button-01); cursor: pointer; transition: background-color 0.3s ease, transform 0.2s ease; }
+.bg-warning:hover { background: var(--warning); }
+.bg-info:hover { background: var(--info); }
+.bg-primary:hover { background: var(--green-600); }
 </style>

--- a/src/main/webapp/WEB-INF/tags/project_card.tag
+++ b/src/main/webapp/WEB-INF/tags/project_card.tag
@@ -14,12 +14,12 @@
 <c:set var="label" value="${status.label}" />
 <c:set var="contentGap" value="${status.name() == 'SUBSCRIPTION' ? '24px' : (status.name() == 'ANNOUNCEMENT' ? '20px' : '32px')}" />
 
-<div class="project-card">
+<div class="project-card" onclick="location.href='${pageContext.request.contextPath}/project/${id}'">
     <div class="card-image">
     	<img class="thumbnail" src="${thumbnailUrl}" alt="project thumnail" />
         <t:status_badge className="badge" label="${label}" status="${status.badgeStatus}"/>
-        <button class="interest-btn" onclick="starProject('2', '${id}', this)">
-        	<t:icon name="seedling" color="${isStarred ? 'var(--green-600)' : 'var(--gray-900)'}" />
+        <button class="interest-btn" onclick="event.stopPropagation(); toggleStarred(this,${!isStarred}); starProject('2', '${id}', this);">
+        	<t:icon name="heart_filled" size="26" color="${isStarred ? 'var(--green-600)' : 'var(--gray-900)'}" />
         </button>
     </div>
     
@@ -86,7 +86,7 @@
     object-position: center; 
 }
 .badge { position: absolute; top: 16px; left: 16px;}
-.interest-btn {position: absolute; top: 18px; right: 16px; border:none; background-color: transparent; cursor:pointer;} 
+.interest-btn {position: absolute; top: 18px; right: 16px; border:none; background-color: transparent; cursor:pointer; filter: drop-shadow(0px 2px 6px rgba(0, 0, 0, 0.5));}
 .card-content { display: flex; flex-direction:column; padding: 24px; }
 .card-title { font: var(--font-subtitle-01); color: var(--gray-900);}
 .card-info { display:flex; flex-direction:column; gap:4px}
@@ -101,6 +101,9 @@
 .info-list {display:flex; flex-direction:column; gap:4px;}
 .info-list p { display: flex; justify-content: space-between; font: var(--font-caption-01); }
 .btn-action { width: 100%; padding: 12px; border: none; border-radius: var(--radius-s); background-color:var(--gray-900); color: white; font: var(--font-button-01); cursor: pointer; transition: background-color 0.3s ease, transform 0.2s ease; }
+.project-card:hover .bg-warning { background-color: var(--warning); }
+.project-card:hover .bg-info { background-color: var(--info); }
+.project-card:hover .bg-primary { background-color: var(--green-600); }
 .bg-warning:hover { background: var(--warning); }
 .bg-info:hover { background: var(--info); }
 .bg-primary:hover { background: var(--green-600); }

--- a/src/main/webapp/WEB-INF/tags/project_card.tag
+++ b/src/main/webapp/WEB-INF/tags/project_card.tag
@@ -4,6 +4,8 @@
 <%@ attribute name="status" type="com.animalfarm.mlf.constants.ProjectStatus" required="true" %> <%-- 청약중, 공고중, 진행중 --%>
 <%@ attribute name="title" required="true" %>
 <%@ attribute name="id" required="true"%>
+<%@ attribute name="isStarred" required="true" type="java.lang.Boolean" %>
+<%@ attribute name="thumbnailUrl" required="false" %>
 <%@ attribute name="endTime" required="true" %>
 <%@ attribute name="upperDate" required="true" %>
 <%@ attribute name="lowerDate" required="true" %>
@@ -14,9 +16,10 @@
 
 <div class="project-card">
     <div class="card-image">
+    	<img class="thumbnail" src="${thumbnailUrl}" alt="project thumnail" />
         <t:status_badge className="badge" label="${label}" status="${status.badgeStatus}"/>
-        <button class="interest-btn">
-        	<t:icon name="seedling"/>
+        <button class="interest-btn" onclick="starProject('2', '${id}', this)">
+        	<t:icon name="seedling" color="${isStarred ? 'var(--green-600)' : 'var(--gray-900)'}" />
         </button>
     </div>
     
@@ -74,7 +77,14 @@
 
 <style>
 .project-card { background: white; border-radius: var(--radius-l); overflow: hidden; box-shadow: 0 4px 12px rgba(0,0,0,0.05); margin-bottom: 24px; cursor:pointer; }
-.card-image { height: 200px; background: #e5e5e5; position: relative; }
+.card-image { height: 220px; background: #e5e5e5; position: relative; }
+.card-image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover; 
+    
+    object-position: center; 
+}
 .badge { position: absolute; top: 16px; left: 16px;}
 .interest-btn {position: absolute; top: 18px; right: 16px; border:none; background-color: transparent; cursor:pointer;} 
 .card-content { display: flex; flex-direction:column; padding: 24px; }

--- a/src/main/webapp/WEB-INF/tags/region_accordian.tag
+++ b/src/main/webapp/WEB-INF/tags/region_accordian.tag
@@ -1,0 +1,136 @@
+<%@ tag language="java" pageEncoding="UTF-8" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+
+<c:set var="regions">
+    전국 전체:;
+    서울특별시:강남구,강동구,강북구,강서구,관악구,광진구,구로구,금천구,노원구,도봉구,동대문구,동작구,마포구,서대문구,서초구,성동구,성북구,송파구,양천구,영등포구,용산구,은평구,종로구,중구,중랑구;
+    부산광역시:강서구,금정구,기장군,남구,동구,동래구,부산진구,북구,사상구,사하구,서구,수영구,연제구,영도구,중구,해운대구;
+    대구광역시:남구,달서구,달성군,동구,북구,서구,수성구,중구,군위군;
+    인천광역시:강화군,계양구,미추홀구,남동구,동구,부평구,서구,연수구,옹진군,중구;
+    광주광역시:광산구,남구,동구,북구,서구;
+    대전광역시:대덕구,동구,서구,유성구,중구;
+    울산광역시:남구,동구,북구,울주군,중구;
+    세종특별자치시:세종시;
+    경기도:가평군,고양시,과천시,광명시,광주시,구리시,군포시,김포시,남양주시,동두천시,부천시,성남시,수원시,시흥시,안산시,안성시,안양시,양주시,양평군,여주시,연천군,오산시,용인시,의왕시,의정부시,이천시,파주시,평택시,포천시,하남시,화성시;
+    강원도:강릉시,고성군,동해시,삼척시,속초시,양구군,양양군,영월군,원주시,인제군,정선군,철원군,춘천시,태백시,평창군,홍천군,화천군,횡성군;
+    충청북도:괴산군,단양군,보은군,영동군,옥천군,음성군,제천시,증평군,진천군,청주시,충주시;
+    충청남도:계룡시,공주시,금산군,논산시,당진시,보령시,부여군,서산시,서천군,아산시,예산군,천안시,청양군,태안군,홍성군;
+    전라북도:고창군,군산시,김제시,남원시,무주군,부안군,순창군,완주군,익산시,임실군,장수군,전주시,진안군,정읍시;
+    전라남도:강진군,고흥군,곡성군,광양시,구례군,나주시,담양군,목포시,무안군,보성군,순천시,신안군,여수시,영광군,영암군,완도군,장성군,장흥군,진도군,함평군,해남군,화순군;
+    경상북도:경산시,경주시,고령군,구미시,김천시,문경시,봉화군,상주시,성주군,안동시,영덕군,영양군,영주시,영천시,예천군,울릉군,울진군,의성군,청도군,청송군,칠곡군,포항시;
+    경상남도:거제시,거창군,고성군,김해시,남해군,밀양시,사천시,산청군,양산시,의령군,진주시,창녕군,창원시,통영시,하동군,함안군,함양군,합천군;
+    제주특별자치도:제주시,서귀포시
+</c:set>
+
+<div class="region-accordion-container">
+    <%-- 데이터 파싱 및 반복문 통합 --%>
+    <c:forEach var="raw" items="${fn:split(regions, ';')}">
+        <c:set var="parts" value="${fn:split(raw, ':')}" />
+        <c:set var="mainRegion" value="${fn:trim(parts[0])}" />
+        <c:set var="subRegions" value="${fn:trim(parts[1])}" />
+        
+        <div class="region-item ${mainRegion == '전국 전체' ? 'active' : ''}">
+            <div class="region-header ${mainRegion == '전국 전체' ? 'no-arrow' : ''}" onclick="toggleAccordion(this)">
+                ${mainRegion}
+                <c:if test="${mainRegion != '전국 전체'}">
+                    <span class="arrow">▼</span>
+                </c:if>
+            </div>
+            
+            <%-- 세부 지역이 있는 경우에만 영역 생성 --%>
+            <c:if test="${not empty subRegions}">
+                <div class="region-content">
+                    <ul>
+                        <c:forEach var="sub" items="${fn:split(subRegions, ',')}">
+                            <li>${sub}</li>
+                        </c:forEach>
+                    </ul>
+                </div>
+            </c:if>
+        </div>
+    </c:forEach>
+</div>
+
+<script>
+function toggleAccordion(header) {
+    const item = header.parentElement;
+    const isActive = item.classList.contains('open');
+    
+    // 다른 열려있는 메뉴 닫기 (선택 사항)
+    document.querySelectorAll('.region-item').forEach(el => {el.classList.remove('open');el.classList.remove('active');});
+    
+    // 클릭한 메뉴 토글
+    if (!isActive) {
+        item.classList.add('open');
+        item.classList.add('active');
+    }
+}
+</script>
+
+<style>
+.region-accordion-container {
+    width: 280px;
+    height: 100%; /* 요청하신 고정 높이 */
+    background: white;
+    border: 1px solid var(--gray-100);
+    border-radius: var(--radius-l);
+    overflow-y: auto; /* 내용이 높이를 넘어가면 스크롤 */
+    box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+}
+
+/* 스크롤바 커스텀 (선택) */
+.region-accordion-container::-webkit-scrollbar { width: 4px; }
+.region-accordion-container::-webkit-scrollbar-thumb { background: var(--gray-200); border-radius: 2px; }
+
+.region-item {
+    border-bottom: 1px solid var(--gray-50);
+}
+
+.region-header {
+    padding: 16px 20px;
+    font: var(--font-caption-02);
+    color: var(--gray-700);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    cursor: pointer;
+    background: white;
+    transition: all 0.2s ease;
+}
+
+.region-header:hover { background: #f7fcf5;color: var(--green-600); /* 마우스만 올려도 글자색이 변하도록 설정 */ }
+
+/* 3. 활성화된(선택된) 상태의 스타일 (Active/Active Item) */
+.region-item.active .region-header {
+    background: #f7fcf5; /* 이미지의 연한 녹색 배경 */
+    color: var(--green-600);
+    font-weight: 600;
+}
+
+.arrow {
+    font-size: 6px;
+    transition: transform 0.3s;
+    color: var(--gray-400);
+}
+
+/* 펼쳐졌을 때 스타일 */
+.region-item.open .region-content { display: block; }
+.region-item.open .arrow { transform: rotate(180deg); }
+
+.region-content {
+    display: none;
+    background: #fafafa;
+    padding: 8px 0;
+}
+
+.region-content ul { list-style: none; padding: 0; margin: 0; }
+.region-content li {
+    padding: 10px 40px;
+    font: var(--font-caption-01);
+    color: var(--gray-500);
+    cursor: pointer;
+}
+
+.region-content li:hover { color: var(--green-600); background: #f0f0f0; }
+</style>

--- a/src/main/webapp/WEB-INF/tags/search_bar.tag
+++ b/src/main/webapp/WEB-INF/tags/search_bar.tag
@@ -2,8 +2,8 @@
 <%@ taglib prefix="t" tagdir="/WEB-INF/tags" %>
 
 <div class="search-container col-4">
-    <input type="text" placeholder="검색어를 입력해주세요" class="search-input">
-    <button class="search-icon-btn">
+    <input type="text" placeholder="검색어를 입력해주세요" onkeyup="if(window.event.keyCode==13){searchKeyword()}" class="search-input">
+    <button class="search-icon-btn" onclick="searchKeyword()">
         <t:icon name="search" size="20" color="var(--gray-900)"/>
     </button>
 </div>

--- a/src/main/webapp/WEB-INF/tags/search_bar.tag
+++ b/src/main/webapp/WEB-INF/tags/search_bar.tag
@@ -1,0 +1,37 @@
+<%@ tag language="java" pageEncoding="UTF-8" body-content="empty" %>
+<%@ taglib prefix="t" tagdir="/WEB-INF/tags" %>
+
+<div class="search-container col-4">
+    <input type="text" placeholder="검색어를 입력해주세요" class="search-input">
+    <button class="search-icon-btn">
+        <t:icon name="search" size="20" color="var(--gray-900)"/>
+    </button>
+</div>
+
+<style>
+.search-container {
+    position: relative;
+    height: 40px;
+}
+.search-input {
+    width: 100%;
+    height: 100%;
+    padding: 0px;
+    border-radius: var(--radius-xl);
+    border: 1px solid var(--gray-400);
+    font: var(--font-body-01);
+    outline: none;
+}
+.search-input:focus {
+    border-color: var(--green-600);
+}
+.search-icon-btn {
+    position: absolute;
+    right: 20px;
+    top: 50%;
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    cursor: pointer;
+}
+</style>

--- a/src/main/webapp/WEB-INF/tags/status_badge.tag
+++ b/src/main/webapp/WEB-INF/tags/status_badge.tag
@@ -14,12 +14,12 @@
 	font: var(--font-button-02); 
 }
 
-.onNotifying {
+.announcement {
 	background-color: var(--info-light);
 	color : var(--info);
 }
 
-.onSubscription {
+.subscription {
 	background-color: var(--warning-light);
 	color : var(--warning);
 }

--- a/src/main/webapp/WEB-INF/tags/status_badge.tag
+++ b/src/main/webapp/WEB-INF/tags/status_badge.tag
@@ -1,0 +1,36 @@
+<%@ tag language="java" pageEncoding="UTF-8" body-content="empty" %>
+<%@ attribute name="className" required="false" %>
+<%@ attribute name="status" required="true" %>
+<%@ attribute name="label" required="true" %>
+
+<div class="${className} status-badge ${status}">
+    ${label}
+</div>
+
+<style>
+.status-badge {
+	padding: 4px 12px;
+	border-radius: var(--radius-s);
+	font: var(--font-button-02); 
+}
+
+.onNotifying {
+	background-color: var(--info-light);
+	color : var(--info);
+}
+
+.onSubscription {
+	background-color: var(--warning-light);
+	color : var(--warning);
+}
+
+.inProgress {
+	background-color: var(--green-0);
+	color : var(--green-700);
+}
+
+.others{
+	background-color: var(--gray-100);
+	color : var(--gray-600);
+}
+</style>

--- a/src/main/webapp/WEB-INF/views/layout.jsp
+++ b/src/main/webapp/WEB-INF/views/layout.jsp
@@ -8,6 +8,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>${param.title != null ? param.title : '마이리틀스마트팜'}</title>
     <link rel="stylesheet" href="${pageContext.request.contextPath}/resources/css/common.css">
+    <script>
+        // 전역 변수로 선언 (보통 'ctx' 또는 'contextPath'라고 명명)
+        const ctx = "${pageContext.request.contextPath}";
+    </script>
 </head>
 <body>
 

--- a/src/main/webapp/WEB-INF/views/project/project_card_list.jsp
+++ b/src/main/webapp/WEB-INF/views/project/project_card_list.jsp
@@ -29,6 +29,8 @@
                 status="${statusEnum}" 
                 title="${project.projectName} ${project.projectRound}회차"
                 id="${project.projectId}"
+                isStarred="${project.isStarred}"
+                thumbnailUrl="${project.thumbnailUrl}"
                 endTime="${endTime}"
                 upperDate="${upperDate}"
                 lowerDate="${lowerDate}" 

--- a/src/main/webapp/WEB-INF/views/project/project_card_list.jsp
+++ b/src/main/webapp/WEB-INF/views/project/project_card_list.jsp
@@ -1,0 +1,38 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="t" tagdir="/WEB-INF/tags" %>
+<%@ page import="com.animalfarm.mlf.constants.ProjectStatus" %>
+
+<c:forEach var="project" items="${projectList}">
+    <div class="col-4">
+        <%-- 1. status 변환 로직: DTO의 String 상태값을 Enum 객체로 변환 --%>
+            <c:set var="statusEnum" value="${ProjectStatus.valueOf(project.projectStatus)}" />
+            
+            <%-- 2. upperDate 처리 (청약중일 때만 청약기간, 공고중일 때만 공고기간) --%>
+	        <c:set var="upperDate" value="${statusEnum.name() == 'SUBSCRIPTION' 
+	                                        ? String.format('%tF ~ %tF', project.subscriptionStartDate, project.subscriptionEndDate) 
+	                                        : (statusEnum.name() == 'ANNOUNCEMENT' 
+	                                            ? String.format('%tF ~ %tF', project.announcementStartDate, project.announcementEndDate) 
+	                                            : '')}" />
+	        <c:set var="endTime" value="${statusEnum.name() == 'SUBSCRIPTION'
+	        								? project.subscriptionEndDate : statusEnum.name() == 'ANNOUNCEMENT'
+	        								? project.announcementEndDate : ''}"/>
+	
+	        <%-- 3. lowerDate 처리 (공고중일 때 청약예정일, 진행중일 때 운영기간) --%>
+	        <c:set var="lowerDate" value="${statusEnum.name() == 'ANNOUNCEMENT' 
+	                                        ? String.format('%tF ~ %tF', project.subscriptionStartDate, project.subscriptionEndDate) 
+	                                        : (statusEnum.name() == 'INPROGRESS' 
+	                                            ? String.format('%tF ~ %tF', project.projectStartDate, project.projectEndDate) 
+	                                            : '')}" />
+            <%-- 3. 태그 호출 --%>
+            <t:project_card 
+                status="${statusEnum}" 
+                title="${project.projectName} ${project.projectRound}회차"
+                id="${project.projectId}"
+                endTime="${endTime}"
+                upperDate="${upperDate}"
+                lowerDate="${lowerDate}" 
+                percent="${project.subscriptionRate}" 
+            />
+    </div>
+</c:forEach>

--- a/src/main/webapp/WEB-INF/views/project/project_list.jsp
+++ b/src/main/webapp/WEB-INF/views/project/project_list.jsp
@@ -1,0 +1,41 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<%@ taglib prefix="t" tagdir="/WEB-INF/tags" %>
+
+<link rel="stylesheet"
+	href="${pageContext.request.contextPath}/resources/css/project_list.css">
+
+<div class="project-list-container">
+    <div class="section-header">
+        <h2>프로젝트 지도</h2>
+        <p>진행중인 프로젝트를 지도에서 확인하세요</p>
+    </div>
+    
+    <div class="map-area">
+    	<t:region_accordian />
+        <div style="width: 100%; height:100%; background-color: var(--gray-100); border-radius: var(--radius-l)"></div>
+    </div>
+
+    <div class="section-header">
+        <h2>프로젝트 목록</h2>
+        <p>프로젝트를 선택하여 자세한 정보를 확인하세요</p>
+    </div>
+    
+    <div class="list-controls">
+        <div class="filter-group">
+            <t:menu_button label="전체보기" active="true"/>
+            <t:menu_button label="청약중"/>
+            <t:menu_button label="공고중"/>
+            <t:menu_button label="진행중"/>
+        </div>
+        <t:search_bar />
+    </div>
+
+    <div class="row">
+        <div class="col-4"><t:project_card status="청약중" title="경남 밀양 딸기 스마트팜 5호" date="2026.04.10 - 04.12" percent="85" /></div>
+        <div class="col-4"><t:project_card status="청약중" title="경남 밀양 딸기 스마트팜 5호" date="2026.04.10 - 04.12" percent="85" /></div>
+        <div class="col-4"><t:project_card status="공고중" title="경남 밀양 딸기 스마트팜 5호" date="2026.04.10 - 04.12" /></div>
+        <div class="col-4"><t:project_card status="공고중" title="경남 밀양 딸기 스마트팜 5호" date="2026.04.10 - 04.12" /></div>
+        <div class="col-4"><t:project_card status="진행중" title="경남 밀양 딸기 스마트팜 5호" date="2026.04.10 - 04.12" /></div>
+        <div class="col-4"><t:project_card status="진행중" title="경남 밀양 딸기 스마트팜 5호" date="2026.04.10 - 04.12" /></div>
+    </div>
+</div>

--- a/src/main/webapp/WEB-INF/views/project/project_list.jsp
+++ b/src/main/webapp/WEB-INF/views/project/project_list.jsp
@@ -1,5 +1,7 @@
+<%@page import="com.animalfarm.mlf.constants.ProjectStatus"%>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib prefix="t" tagdir="/WEB-INF/tags" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 
 <link rel="stylesheet"
 	href="${pageContext.request.contextPath}/resources/css/project_list.css">
@@ -22,20 +24,77 @@
     
     <div class="list-controls">
         <div class="filter-group">
-            <t:menu_button label="전체보기" active="true"/>
-            <t:menu_button label="청약중"/>
-            <t:menu_button label="공고중"/>
-            <t:menu_button label="진행중"/>
+            <t:menu_button label="전체보기" 
+                       active="${empty param.category}" 
+                       onClick="filterCategory('')"/>
+        	<t:menu_button label="청약중" 
+                       active="${param.category == 'SUBSCRIPTION'}" 
+                       onClick="filterCategory('SUBSCRIPTION')"/>
+        	<t:menu_button label="공고중" 
+                       active="${param.category == 'ANNOUNCEMENT'}" 
+                       onClick="filterCategory('ANNOUNCEMENT')"/>
+        	<t:menu_button label="진행중" 
+                       active="${param.category == 'INPROGRESS'}" 
+                       onClick="filterCategory('INPROGRESS')"/>
         </div>
         <t:search_bar />
     </div>
 
     <div class="row">
-        <div class="col-4"><t:project_card status="청약중" title="경남 밀양 딸기 스마트팜 5호" date="2026.04.10 - 04.12" percent="85" /></div>
-        <div class="col-4"><t:project_card status="청약중" title="경남 밀양 딸기 스마트팜 5호" date="2026.04.10 - 04.12" percent="85" /></div>
-        <div class="col-4"><t:project_card status="공고중" title="경남 밀양 딸기 스마트팜 5호" date="2026.04.10 - 04.12" /></div>
-        <div class="col-4"><t:project_card status="공고중" title="경남 밀양 딸기 스마트팜 5호" date="2026.04.10 - 04.12" /></div>
-        <div class="col-4"><t:project_card status="진행중" title="경남 밀양 딸기 스마트팜 5호" date="2026.04.10 - 04.12" /></div>
-        <div class="col-4"><t:project_card status="진행중" title="경남 밀양 딸기 스마트팜 5호" date="2026.04.10 - 04.12" /></div>
-    </div>
+    <c:forEach var="project" items="${projectList}">
+        <div class="col-4">
+            <%-- 1. status 변환 로직: DTO의 String 상태값을 Enum 객체로 변환 --%>
+            <c:set var="statusEnum" value="${ProjectStatus.valueOf(project.projectStatus)}" />
+            
+            <%-- 2. upperDate 처리 (청약중일 때만 청약기간, 공고중일 때만 공고기간) --%>
+	        <c:set var="upperDate" value="${statusEnum.name() == 'SUBSCRIPTION' 
+	                                        ? String.format('%tF ~ %tF', project.subscriptionStartDate, project.subscriptionEndDate) 
+	                                        : (statusEnum.name() == 'ANNOUNCEMENT' 
+	                                            ? String.format('%tF ~ %tF', project.announcementStartDate, project.announcementEndDate) 
+	                                            : '')}" />
+	
+	        <%-- 3. lowerDate 처리 (공고중일 때 청약예정일, 진행중일 때 운영기간) --%>
+	        <c:set var="lowerDate" value="${statusEnum.name() == 'ANNOUNCEMENT' 
+	                                        ? String.format('%tF ~ %tF', project.subscriptionStartDate, project.subscriptionEndDate) 
+	                                        : (statusEnum.name() == 'INPROGRESS' 
+	                                            ? String.format('%tF ~ %tF', project.projectStartDate, project.projectEndDate) 
+	                                            : '')}" />
+            <%-- 3. 태그 호출 --%>
+            <t:project_card 
+                status="${statusEnum}" 
+                title="${project.projectName} ${project.projectRound}호" 
+                upperDate="${upperDate}"
+                lowerDate="${lowerDate}" 
+                percent="${project.subscriptionRate}" 
+            />
+        </div>
+    </c:forEach>
+    
+    <%-- 검색 결과가 없을 때 처리 --%>
+    <c:if test="${empty projectList}">
+        <div class="col-12" style="text-align: center; padding: 100px 0;">
+            <p style="color: var(--gray-400);">조건에 맞는 프로젝트가 없습니다.</p>
+        </div>
+    </c:if>
 </div>
+</div>
+<script>
+/**
+ * 카테고리 필터링 함수
+ * @param {string} category - Enum 명칭 (SUBSCRIPTION, ANNOUNCEMENT 등)
+ */
+function filterCategory(category) {
+    // 기존의 다른 검색 조건(키워드 등)이 있다면 유지하고 category만 바꿀 수 있도록 구성
+    const url = new URL(window.location.href);
+    
+    if (category) {
+        url.searchParams.set('category', category);
+    } else {
+        // 전체보기 클릭 시 category 파라미터 삭제
+        url.searchParams.delete('category');
+    }
+    
+    // 페이지 이동
+    location.href = url.pathname + url.search;
+}
+ </script>

--- a/src/main/webapp/WEB-INF/views/project/project_list.jsp
+++ b/src/main/webapp/WEB-INF/views/project/project_list.jsp
@@ -5,6 +5,8 @@
 
 <link rel="stylesheet"
 	href="${pageContext.request.contextPath}/resources/css/project_list.css">
+<script src="${pageContext.request.contextPath}/resources/js/domain/project/project_list.js"> </script>
+<script src="${pageContext.request.contextPath}/resources/js/util/timer.js"></script>
 
 <div class="project-list-container">
     <div class="section-header">
@@ -25,50 +27,23 @@
     <div class="list-controls">
         <div class="filter-group">
             <t:menu_button label="전체보기" 
-                       active="${empty param.category}" 
-                       onClick="filterCategory('')"/>
+                       active="${empty param.projectStatus}" 
+                       onClick="filterCategory('', this)"/>
         	<t:menu_button label="청약중" 
-                       active="${param.category == 'SUBSCRIPTION'}" 
-                       onClick="filterCategory('SUBSCRIPTION')"/>
+                       active="${param.projectStatus == 'SUBSCRIPTION'}" 
+                       onClick="filterCategory('SUBSCRIPTION', this)"/>
         	<t:menu_button label="공고중" 
-                       active="${param.category == 'ANNOUNCEMENT'}" 
-                       onClick="filterCategory('ANNOUNCEMENT')"/>
+                       active="${param.projectStatus == 'ANNOUNCEMENT'}" 
+                       onClick="filterCategory('ANNOUNCEMENT', this)"/>
         	<t:menu_button label="진행중" 
-                       active="${param.category == 'INPROGRESS'}" 
-                       onClick="filterCategory('INPROGRESS')"/>
+                       active="${param.projectStatus == 'INPROGRESS'}" 
+                       onClick="filterCategory('INPROGRESS', this)"/>
         </div>
         <t:search_bar />
     </div>
 
-    <div class="row">
-    <c:forEach var="project" items="${projectList}">
-        <div class="col-4">
-            <%-- 1. status 변환 로직: DTO의 String 상태값을 Enum 객체로 변환 --%>
-            <c:set var="statusEnum" value="${ProjectStatus.valueOf(project.projectStatus)}" />
-            
-            <%-- 2. upperDate 처리 (청약중일 때만 청약기간, 공고중일 때만 공고기간) --%>
-	        <c:set var="upperDate" value="${statusEnum.name() == 'SUBSCRIPTION' 
-	                                        ? String.format('%tF ~ %tF', project.subscriptionStartDate, project.subscriptionEndDate) 
-	                                        : (statusEnum.name() == 'ANNOUNCEMENT' 
-	                                            ? String.format('%tF ~ %tF', project.announcementStartDate, project.announcementEndDate) 
-	                                            : '')}" />
-	
-	        <%-- 3. lowerDate 처리 (공고중일 때 청약예정일, 진행중일 때 운영기간) --%>
-	        <c:set var="lowerDate" value="${statusEnum.name() == 'ANNOUNCEMENT' 
-	                                        ? String.format('%tF ~ %tF', project.subscriptionStartDate, project.subscriptionEndDate) 
-	                                        : (statusEnum.name() == 'INPROGRESS' 
-	                                            ? String.format('%tF ~ %tF', project.projectStartDate, project.projectEndDate) 
-	                                            : '')}" />
-            <%-- 3. 태그 호출 --%>
-            <t:project_card 
-                status="${statusEnum}" 
-                title="${project.projectName} ${project.projectRound}호" 
-                upperDate="${upperDate}"
-                lowerDate="${lowerDate}" 
-                percent="${project.subscriptionRate}" 
-            />
-        </div>
-    </c:forEach>
+    <div class="row" id="projectCardContainer">
+    <jsp:include page="/WEB-INF/views/project/project_card_list.jsp" />
     
     <%-- 검색 결과가 없을 때 처리 --%>
     <c:if test="${empty projectList}">
@@ -78,23 +53,3 @@
     </c:if>
 </div>
 </div>
-<script>
-/**
- * 카테고리 필터링 함수
- * @param {string} category - Enum 명칭 (SUBSCRIPTION, ANNOUNCEMENT 등)
- */
-function filterCategory(category) {
-    // 기존의 다른 검색 조건(키워드 등)이 있다면 유지하고 category만 바꿀 수 있도록 구성
-    const url = new URL(window.location.href);
-    
-    if (category) {
-        url.searchParams.set('category', category);
-    } else {
-        // 전체보기 클릭 시 category 파라미터 삭제
-        url.searchParams.delete('category');
-    }
-    
-    // 페이지 이동
-    location.href = url.pathname + url.search;
-}
- </script>

--- a/src/main/webapp/WEB-INF/views/project/project_list.jsp
+++ b/src/main/webapp/WEB-INF/views/project/project_list.jsp
@@ -5,7 +5,7 @@
 
 <link rel="stylesheet"
 	href="${pageContext.request.contextPath}/resources/css/project_list.css">
-<script src="${pageContext.request.contextPath}/resources/js/domain/project/project_list.js"> </script>
+<script type="module" src="${pageContext.request.contextPath}/resources/js/domain/project/project_list.js"> </script>
 <script src="${pageContext.request.contextPath}/resources/js/util/timer.js"></script>
 
 <div class="project-list-container">
@@ -43,13 +43,13 @@
     </div>
 
     <div class="row" id="projectCardContainer">
-    <jsp:include page="/WEB-INF/views/project/project_card_list.jsp" />
-    
-    <%-- 검색 결과가 없을 때 처리 --%>
-    <c:if test="${empty projectList}">
-        <div class="col-12" style="text-align: center; padding: 100px 0;">
-            <p style="color: var(--gray-400);">조건에 맞는 프로젝트가 없습니다.</p>
-        </div>
-    </c:if>
-</div>
+	    <jsp:include page="/WEB-INF/views/project/project_card_list.jsp" />
+	    
+	    <%-- 검색 결과가 없을 때 처리 --%>
+	    <c:if test="${empty projectList}">
+	        <div class="col-12" style="text-align: center; padding: 100px 0;">
+	            <p style="color: var(--gray-400);">조건에 맞는 프로젝트가 없습니다.</p>
+	        </div>
+	    </c:if>
+	</div>
 </div>

--- a/src/main/webapp/resources/css/common.css
+++ b/src/main/webapp/resources/css/common.css
@@ -33,8 +33,11 @@
 
   /* --- 3. Semantic Colors --- */
   --info: #1976d2;
+  --info-light: #e8f1fa;
   --warning: #ffa000;
+  --warning-light: #fff8e1;
   --error: #d32f2f;
+  --error-light: #ffebee;
   --success: #388e3c;
 
   /* --- 4. Layout & Grid System --- */

--- a/src/main/webapp/resources/css/project_list.css
+++ b/src/main/webapp/resources/css/project_list.css
@@ -1,0 +1,39 @@
+@charset "UTF-8";
+
+.project-list-container {
+  padding-block: 40px;
+}
+
+.section-header {
+  margin-bottom: 24px;
+}
+
+.section-header h2 {
+  font: var(--font-header-01);
+  color: var(--gray-900);
+}
+
+.section-header p {
+  font: var(--font-body-01);
+  color: var(--gray-500);
+}
+
+.map-area {
+  display: flex;
+  width: 100%;
+  height: 400px;
+  margin-bottom: 48px;
+  gap: 24px;
+}
+
+.list-controls {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.filter-group {
+  display: flex;
+  gap: 6px;
+}

--- a/src/main/webapp/resources/js/domain/project/project_api.js
+++ b/src/main/webapp/resources/js/domain/project/project_api.js
@@ -5,5 +5,6 @@ export const ProjectApi = {
     getAll: () => http.get(`${ctx}/api/projects/all`),
     getPictures: (id) => http.get(`${ctx}/api/project/picture/${id}/all`),
     insert: (data) => http.post(`${ctx}/api/projects/insert`, data),
-    update: (data) => http.post(`${ctx}/api/projects/update`, data)
+    update: (data) => http.post(`${ctx}/api/projects/update`, data),
+    starProject: (data) => http.post(`${ctx}/api/projects/starred/interest`, data)
 };

--- a/src/main/webapp/resources/js/domain/project/project_api.js
+++ b/src/main/webapp/resources/js/domain/project/project_api.js
@@ -2,9 +2,10 @@
 import { http } from "../../api/http_client.js";
 
 export const ProjectApi = {
-    getAll: () => http.get(`${ctx}/api/projects/all`),
-    getPictures: (id) => http.get(`${ctx}/api/project/picture/${id}/all`),
-    insert: (data) => http.post(`${ctx}/api/projects/insert`, data),
-    update: (data) => http.post(`${ctx}/api/projects/update`, data),
-    starProject: (data) => http.post(`${ctx}/api/projects/starred/interest`, data)
+  getAll: () => http.get(`${ctx}/api/projects/all`),
+  getPictures: (id) => http.get(`${ctx}/api/project/picture/${id}/all`),
+  insert: (data) => http.post(`${ctx}/api/projects/insert`, data),
+  update: (data) => http.post(`${ctx}/api/projects/update`, data),
+  searchProjects: (query) => http.get(`${ctx}/project/list/fragment${query}`),
+  starProject: (data) => http.post(`${ctx}/api/projects/starred`, data),
 };

--- a/src/main/webapp/resources/js/domain/project/project_list.js
+++ b/src/main/webapp/resources/js/domain/project/project_list.js
@@ -1,3 +1,5 @@
+import { ProjectApi } from "./project_api.js";
+
 async function filterCategory(category, element) {
     // 1. 버튼 활성화 UI 즉시 변경 (UX 향상)
     document.querySelectorAll('.menu-btn').forEach(btn => btn.classList.remove('active'));
@@ -16,7 +18,7 @@ async function filterCategory(category, element) {
         // 4. 특정 영역만 교체
         document.getElementById('projectCardContainer').innerHTML = html;
     } catch (error) {
-        console.error('데이터 로드 실패:', error);
+        console.error('데이터 로드 실패: ', error);
     }
 }
 
@@ -34,7 +36,33 @@ async function searchKeyword() {
         
         document.getElementById('projectCardContainer').innerHTML = html;
     } catch (error) {
-        console.error('데이터 로드 실패:', error);
+        console.error('데이터 로드 실패: ', error);
     }
 
 }
+
+async function starProject(userId, projectId, element) {
+    if (!userId) {
+        alert("로그인이 필요한 서비스입니다."); //TODO: 처리 방식 변경
+        return;
+    }
+
+    let body = {userId, projectId};
+
+    try {
+        const response = await ProjectApi.starProject(body);
+
+        const icon = element.querySelector('svg');
+        if (response.isStarred) {
+            icon.style.fill = 'var(--green-600)';
+        } else {
+            icon.style.fill = 'var(--gray-900)';
+        }
+    } catch (error) {
+        console.error('즐겨찾기 요청 실패: ', error);
+    }
+}
+
+window.starProject = starProject;
+window.searchKeyword = searchKeyword;
+window.filterCategory = filterCategory;

--- a/src/main/webapp/resources/js/domain/project/project_list.js
+++ b/src/main/webapp/resources/js/domain/project/project_list.js
@@ -1,0 +1,40 @@
+async function filterCategory(category, element) {
+    // 1. 버튼 활성화 UI 즉시 변경 (UX 향상)
+    document.querySelectorAll('.menu-btn').forEach(btn => btn.classList.remove('active'));
+    if(element) element.classList.add('active');
+
+    // 2. URL 파라미터 변경 (새로고침 없이 주소창만 변경)
+    const url = new URL(window.location.href);
+    if (category) url.searchParams.set('projectStatus', category);
+    else url.searchParams.delete('projectStatus');
+    window.history.pushState({}, '', url);
+    // 3. Fetch로 HTML 조각 요청
+    try {
+        const response = await fetch(ctx+'/project/list/fragment' + url.search);
+        const html = await response.text();
+        
+        // 4. 특정 영역만 교체
+        document.getElementById('projectCardContainer').innerHTML = html;
+    } catch (error) {
+        console.error('데이터 로드 실패:', error);
+    }
+}
+
+async function searchKeyword() {
+    let keyword = document.querySelector('.search-input').value;
+    console.log(keyword);
+    const url = new URL(window.location.href);
+    keyword = keyword.trim();
+    if (keyword) url.searchParams.set('keyword', keyword);
+    else url.searchParams.delete('keyword');
+    window.history.pushState({}, '', url);
+    try {
+        const response = await fetch(ctx+'/project/list/fragment' + url.search);
+        const html = await response.text();
+        
+        document.getElementById('projectCardContainer').innerHTML = html;
+    } catch (error) {
+        console.error('데이터 로드 실패:', error);
+    }
+
+}

--- a/src/main/webapp/resources/js/domain/project/project_list.js
+++ b/src/main/webapp/resources/js/domain/project/project_list.js
@@ -1,68 +1,72 @@
 import { ProjectApi } from "./project_api.js";
 
 async function filterCategory(category, element) {
-    // 1. 버튼 활성화 UI 즉시 변경 (UX 향상)
-    document.querySelectorAll('.menu-btn').forEach(btn => btn.classList.remove('active'));
-    if(element) element.classList.add('active');
+  // 1. 버튼 활성화 UI 즉시 변경 (UX 향상)
+  document
+    .querySelectorAll(".menu-btn")
+    .forEach((btn) => btn.classList.remove("active"));
+  if (element) element.classList.add("active");
 
-    // 2. URL 파라미터 변경 (새로고침 없이 주소창만 변경)
-    const url = new URL(window.location.href);
-    if (category) url.searchParams.set('projectStatus', category);
-    else url.searchParams.delete('projectStatus');
-    window.history.pushState({}, '', url);
-    // 3. Fetch로 HTML 조각 요청
-    try {
-        const response = await fetch(ctx+'/project/list/fragment' + url.search);
-        const html = await response.text();
-        
-        // 4. 특정 영역만 교체
-        document.getElementById('projectCardContainer').innerHTML = html;
-    } catch (error) {
-        console.error('데이터 로드 실패: ', error);
-    }
+  // 2. URL 파라미터 변경 (새로고침 없이 주소창만 변경)
+  const url = new URL(window.location.href);
+  if (category) url.searchParams.set("projectStatus", category);
+  else url.searchParams.delete("projectStatus");
+  window.history.pushState({}, "", url);
+  // 3. Fetch로 HTML 조각 요청
+  try {
+    const html = await ProjectApi.searchProjects(url.search);
+
+    // 4. 특정 영역만 교체
+    document.getElementById("projectCardContainer").innerHTML = html;
+  } catch (error) {
+    console.error("데이터 로드 실패: ", error);
+  }
 }
 
 async function searchKeyword() {
-    let keyword = document.querySelector('.search-input').value;
-    console.log(keyword);
-    const url = new URL(window.location.href);
-    keyword = keyword.trim();
-    if (keyword) url.searchParams.set('keyword', keyword);
-    else url.searchParams.delete('keyword');
-    window.history.pushState({}, '', url);
-    try {
-        const response = await fetch(ctx+'/project/list/fragment' + url.search);
-        const html = await response.text();
-        
-        document.getElementById('projectCardContainer').innerHTML = html;
-    } catch (error) {
-        console.error('데이터 로드 실패: ', error);
-    }
+  let keyword = document.querySelector(".search-input").value;
+  console.log(keyword);
+  const url = new URL(window.location.href);
+  keyword = keyword.trim();
+  if (keyword) url.searchParams.set("keyword", keyword);
+  else url.searchParams.delete("keyword");
+  window.history.pushState({}, "", url);
+  try {
+    const html = await ProjectApi.searchProjects(url.search);
 
+    document.getElementById("projectCardContainer").innerHTML = html;
+  } catch (error) {
+    console.error("데이터 로드 실패: ", error);
+  }
 }
 
 async function starProject(userId, projectId, element) {
-    if (!userId) {
-        alert("로그인이 필요한 서비스입니다."); //TODO: 처리 방식 변경
-        return;
-    }
+  if (!userId) {
+    alert("로그인이 필요한 서비스입니다."); //TODO: 처리 방식 변경
+    return;
+  }
 
-    let body = {userId, projectId};
+  let body = { userId, projectId };
 
-    try {
-        const response = await ProjectApi.starProject(body);
+  try {
+    const curStarredStatus = await ProjectApi.starProject(body);
+    toggleStarred(element, curStarredStatus);
+  } catch (error) {
+    console.error("즐겨찾기 요청 실패: ", error);
+  }
+}
 
-        const icon = element.querySelector('svg');
-        if (response.isStarred) {
-            icon.style.fill = 'var(--green-600)';
-        } else {
-            icon.style.fill = 'var(--gray-900)';
-        }
-    } catch (error) {
-        console.error('즐겨찾기 요청 실패: ', error);
-    }
+function toggleStarred(element, isStarred) {
+  console.log(element, isStarred);
+  const icon = element.querySelector("svg path");
+  if (isStarred) {
+    icon.style.fill = "var(--green-300)";
+  } else {
+    icon.style.fill = "var(--gray-900)";
+  }
 }
 
 window.starProject = starProject;
 window.searchKeyword = searchKeyword;
 window.filterCategory = filterCategory;
+window.toggleStarred = toggleStarred;

--- a/src/main/webapp/resources/js/util/timer.js
+++ b/src/main/webapp/resources/js/util/timer.js
@@ -1,0 +1,48 @@
+function startGlobalTimer() {
+    const updateTimers = () => {
+        const now = new Date();
+
+        document.querySelectorAll('.timer-display').forEach(display => {
+            const endTimeStr = display.getAttribute('data-end-time');
+            const status = display.getAttribute('data-status');
+            if (!endTimeStr) return;
+
+            const endTime = new Date(endTimeStr);
+            const diff = endTime - now;
+
+            if (diff <= 0) {
+                display.textContent = "청약 마감";
+                display.classList.replace('text-error', 'text-gray-400');
+                return;
+            }
+
+            // 시간 계산 로직
+            const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+            const hours = String(Math.floor((diff / (1000 * 60 * 60)) % 24)).padStart(2, '0');
+            const mins = String(Math.floor((diff / (1000 * 60)) % 60)).padStart(2, '0');
+            const secs = String(Math.floor((diff / 1000) % 60)).padStart(2, '0');
+
+            if (status==='SUBSCRIPTION') {
+                if (days > 0) {
+                    display.textContent = `마감까지 ${days}일 ${hours}:${mins}:${secs}`;
+                } else {
+                    display.textContent = `마감까지 ${hours}:${mins}:${secs}`;
+                }
+            } else if (status==='ANNOUNCEMENT') {
+                if (days > 0) {
+                    display.textContent = `시작까지 ${days}일 ${hours}:${mins}:${secs}`;
+                } else {
+                    display.textContent = `시작까지 ${hours}:${mins}:${secs}`;
+                }
+
+            }
+        });
+    };
+
+    // 초기 실행 및 1초 주기 반복
+    updateTimers();
+    setInterval(updateTimers, 1000);
+}
+
+// DOM이 로드된 후 실행
+document.addEventListener('DOMContentLoaded', startGlobalTimer);

--- a/src/main/webapp/resources/js/util/timer.js
+++ b/src/main/webapp/resources/js/util/timer.js
@@ -1,48 +1,42 @@
 function startGlobalTimer() {
-    const updateTimers = () => {
-        const now = new Date();
+  const updateTimers = () => {
+    const now = new Date();
 
-        document.querySelectorAll('.timer-display').forEach(display => {
-            const endTimeStr = display.getAttribute('data-end-time');
-            const status = display.getAttribute('data-status');
-            if (!endTimeStr) return;
+    document.querySelectorAll(".timer-display").forEach((display) => {
+      const endTimeStr = display.getAttribute("data-end-time");
+      const status = display.getAttribute("data-status");
+      if (!endTimeStr) return;
 
-            const endTime = new Date(endTimeStr);
-            const diff = endTime - now;
+      const endTime = new Date(endTimeStr);
+      const diff = endTime - now;
 
-            if (diff <= 0) {
-                display.textContent = "청약 마감";
-                display.classList.replace('text-error', 'text-gray-400');
-                return;
-            }
+      if (diff <= 0) {
+        display.textContent = "청약 마감";
+        display.classList.replace("text-error", "text-gray-400");
+        return;
+      }
 
-            // 시간 계산 로직
-            const days = Math.floor(diff / (1000 * 60 * 60 * 24));
-            const hours = String(Math.floor((diff / (1000 * 60 * 60)) % 24)).padStart(2, '0');
-            const mins = String(Math.floor((diff / (1000 * 60)) % 60)).padStart(2, '0');
-            const secs = String(Math.floor((diff / 1000) % 60)).padStart(2, '0');
+      const totalSeconds = Math.floor(diff / 1000);
+      // 시간 계산 로직
+      const hours = String(Math.floor(totalSeconds / 3600)).padStart(2, "0");
+      const mins = String(Math.floor((totalSeconds % 3600) / 60)).padStart(
+        2,
+        "0",
+      );
+      const secs = String(Math.floor(totalSeconds % 60)).padStart(2, "0");
 
-            if (status==='SUBSCRIPTION') {
-                if (days > 0) {
-                    display.textContent = `마감까지 ${days}일 ${hours}:${mins}:${secs}`;
-                } else {
-                    display.textContent = `마감까지 ${hours}:${mins}:${secs}`;
-                }
-            } else if (status==='ANNOUNCEMENT') {
-                if (days > 0) {
-                    display.textContent = `시작까지 ${days}일 ${hours}:${mins}:${secs}`;
-                } else {
-                    display.textContent = `시작까지 ${hours}:${mins}:${secs}`;
-                }
+      if (status === "SUBSCRIPTION") {
+        display.textContent = `마감까지 ${hours}:${mins}:${secs}`;
+      } else if (status === "ANNOUNCEMENT") {
+        display.textContent = `시작까지 ${hours}:${mins}:${secs}`;
+      }
+    });
+  };
 
-            }
-        });
-    };
-
-    // 초기 실행 및 1초 주기 반복
-    updateTimers();
-    setInterval(updateTimers, 1000);
+  // 초기 실행 및 1초 주기 반복
+  updateTimers();
+  setInterval(updateTimers, 1000);
 }
 
 // DOM이 로드된 후 실행
-document.addEventListener('DOMContentLoaded', startGlobalTimer);
+document.addEventListener("DOMContentLoaded", startGlobalTimer);


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- 페이지 퍼블리싱
- 조건 조회, 전체 조회
- 관심 프로젝트 등록

## 📝 변경 사항 (Key Changes)
- [x] 컨트롤러, 뷰컨트롤러 내용 수정
- [x] ProjectStatus Enum 추가
- [x] 현재 관심 상태 가져오는 API 추가
- [x] 페이지 내부에서 쓰이는 컴포넌트들(메뉴버튼, 검색창, 프로젝트 카드) 추가
- [x] 청약/공지 마감 시간 타이머 추가 (timer.js)

## 📸 스크린샷 (Screenshots / Demos)
| Feature | Screenshot |
| :--- | :--- |
| 목록 페이지 전체 | <img width="1080" height="1792" alt="image" src="https://github.com/user-attachments/assets/8e488a82-9e53-4f06-ab04-fb059e5b972f" />|

## 🔗 연관된 이슈 (Related Issues)
- Close #14 

## 🧐 주요 리뷰 포인트 (Review Point)
- 전체 화면
  - project_list.jsp
- 프로젝트 카드 목록
  - project_card_list.jsp
- 프로젝트 카드
  - project_card.tag

프로젝트 목록 화면 안에 프로젝트 카드 목록이 있고, 프로젝트 카드 목록 안에 카드가 있음.
조건 조회를 하면 프로젝트 카드 목록만 다시 만들어보내고, innerHtml 교체 방식으로 화면 보여줌.
관심 프로젝트 등록/해제 시 아이콘 먼저 변경 시키고, 이후에 응답 받아와서 한번더 적용하도록 함. (UX 고려)

## ✅ 최종 PR전 체크 리스트 (Checklist)
- [x] 코딩 컨벤션(Checkstyle)을 준수하였는가?
- [x] 불필요한 주석이나 시스템 로그(console.log, print)를 제거하였는가?
- [x] 변경 사항에 대한 테스트를 완료하였는가?
- [x] 관련 문서를 업데이트하였는가?