### PR TITLE
[FEAT] 청약 취소 기초 작업

### DIFF
--- a/src/main/java/com/animalfarm/mlf/common/http/ApiResponse.java
+++ b/src/main/java/com/animalfarm/mlf/common/http/ApiResponse.java
@@ -12,5 +12,15 @@ import lombok.Setter;
 public class ApiResponse<T> {
 	private String message;
 	private T payload;
+	
+	// 데이터 없이 메시지만 보내는 응답
+	public static <T> ApiResponse<T> message(String message) {
+		return new ApiResponse<>(message, null);
+	}
+
+	// 데이터를 포함한 응답
+	public static <T> ApiResponse<T> messageWithData(String message, T data) {
+		return new ApiResponse<>(message, data);
+	}
 }
 

--- a/src/main/java/com/animalfarm/mlf/common/http/ApiResponse.java
+++ b/src/main/java/com/animalfarm/mlf/common/http/ApiResponse.java
@@ -1,0 +1,16 @@
+package com.animalfarm.mlf.common.http;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApiResponse<T> {
+	private String message;
+	private T payload;
+}
+

--- a/src/main/java/com/animalfarm/mlf/common/http/ExternalApiUtil.java
+++ b/src/main/java/com/animalfarm/mlf/common/http/ExternalApiUtil.java
@@ -1,0 +1,67 @@
+package com.animalfarm.mlf.common.http;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ExternalApiUtil {
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 외부 API 호출 공통 메서드
+     * @param url 호출 주소
+     * @param method HttpMethod (GET, POST 등)
+     * @param body 요청 바디 (없으면 null)
+     * @param responseType ParameterizedTypeReference (제네릭 타입 보존용)
+     */
+    public <T> T callApi(String url, HttpMethod method, Object body, ParameterizedTypeReference<ApiResponse<T>> responseType) {
+        
+        // 1. 헤더 설정 (JSON 통신 표준화)
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<Object> entity = new HttpEntity<>(body, headers);
+
+        try {
+            // 2. API 호출
+            ResponseEntity<ApiResponse<T>> response = restTemplate.exchange(url, method, entity, responseType);
+
+            // 3. 성공 응답 처리 (2xx)
+            if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+                log.info("[API Success] URL: {}, Msg: {}", url, response.getBody().getMessage());
+                return response.getBody().getPayload();
+            }
+            
+            throw new RuntimeException("API 응답이 비어있습니다.");
+
+        } catch (HttpClientErrorException e) {
+        	// 핵심: 증권사가 보낸 에러 JSON 바디를 ApiResponse 객체로 변환
+            String errorBody = e.getResponseBodyAsString();
+            log.error("[API Error Body] {}", errorBody);
+
+            try {
+                // ApiResponse 구조에 맞게 읽어옴
+                ApiResponse<?> apiResponse = objectMapper.readValue(errorBody, ApiResponse.class);
+                // 증권사가 보낸 "잔액 부족", "이미 소각됨" 등의 실질적 메시지를 던짐
+                throw new RuntimeException(apiResponse.getMessage());
+            } catch (Exception parseException) {
+                // 파싱 실패 시 기본 에러 메시지
+                throw new RuntimeException("증권사 서비스 오류가 발생했습니다. (Status: " + e.getRawStatusCode() + ")");
+            }
+            
+        } catch (Exception e) {
+            log.error("[API System Error] URL: {}, Message: {}", url, e.getMessage());
+            throw new RuntimeException("시스템 오류로 API를 호출할 수 없습니다.");
+        }
+    }
+}

--- a/src/main/java/com/animalfarm/mlf/config/WebConfig.java
+++ b/src/main/java/com/animalfarm/mlf/config/WebConfig.java
@@ -9,6 +9,7 @@ import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -67,4 +68,14 @@ public class WebConfig implements WebMvcConfigurer {
 		registry.addResourceHandler("/uploads/**")
 			.addResourceLocations("file:///C:/mlfarm-data/uploads/");
 	}
+	
+	@Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+
+	@Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
 }

--- a/src/main/java/com/animalfarm/mlf/domain/common/ApiResponse.java
+++ b/src/main/java/com/animalfarm/mlf/domain/common/ApiResponse.java
@@ -1,9 +1,0 @@
-package com.animalfarm.mlf.domain.common;
-
-import lombok.Getter;
-
-@Getter
-public class ApiResponse<T> {
-    private String message;
-    private T payload;
-}

--- a/src/main/java/com/animalfarm/mlf/domain/project/ProjectService.java
+++ b/src/main/java/com/animalfarm/mlf/domain/project/ProjectService.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
-import com.animalfarm.mlf.domain.common.ApiResponse;
+import com.animalfarm.mlf.common.http.ApiResponse;
 import com.animalfarm.mlf.domain.project.dto.FarmDTO;
 import com.animalfarm.mlf.domain.project.dto.ImgEditable;
 import com.animalfarm.mlf.domain.project.dto.ProjectDTO;

--- a/src/main/java/com/animalfarm/mlf/domain/subscription/SubscriptionController.java
+++ b/src/main/java/com/animalfarm/mlf/domain/subscription/SubscriptionController.java
@@ -1,0 +1,33 @@
+package com.animalfarm.mlf.domain.subscription;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.animalfarm.mlf.common.http.ApiResponse;
+import com.animalfarm.mlf.domain.subscription.dto.SubscriptionSelectDTO;
+
+@RestController
+@RequestMapping("/api/subscription")
+public class SubscriptionController {
+	
+	@Autowired
+	SubscriptionService subscriptionService;
+	
+	@PostMapping("/cancel")
+	public ResponseEntity<ApiResponse<Object>> cancelSubscription (@RequestBody SubscriptionSelectDTO subscriptionSelectDTO) {
+		boolean isSuccess = subscriptionService.selectAndCancel(subscriptionSelectDTO);
+		
+		if (isSuccess) {
+            // 디자인 가이드에 따른 성공 메시지 반환
+            return ResponseEntity.ok(ApiResponse.message("청약 취소가 완료되었습니다."));
+        } else {
+            // 실패 시 처리
+            return ResponseEntity.badRequest().body(ApiResponse.message("청약 취소에 실패했습니다. 내역을 확인해주세요."));
+        }
+	}
+	
+}

--- a/src/main/java/com/animalfarm/mlf/domain/subscription/SubscriptionRepository.java
+++ b/src/main/java/com/animalfarm/mlf/domain/subscription/SubscriptionRepository.java
@@ -1,0 +1,12 @@
+package com.animalfarm.mlf.domain.subscription;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import com.animalfarm.mlf.domain.subscription.dto.SubscriptionHistDTO;
+import com.animalfarm.mlf.domain.subscription.dto.SubscriptionSelectDTO;
+
+@Mapper
+public interface SubscriptionRepository {
+	
+	public abstract SubscriptionHistDTO select(SubscriptionSelectDTO subscriptionSelectDTO);
+}

--- a/src/main/java/com/animalfarm/mlf/domain/subscription/SubscriptionService.java
+++ b/src/main/java/com/animalfarm/mlf/domain/subscription/SubscriptionService.java
@@ -1,0 +1,49 @@
+package com.animalfarm.mlf.domain.subscription;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.animalfarm.mlf.common.http.ApiResponse;
+import com.animalfarm.mlf.common.http.ExternalApiUtil;
+import com.animalfarm.mlf.domain.subscription.dto.SubscriptionHistDTO;
+import com.animalfarm.mlf.domain.subscription.dto.SubscriptionSelectDTO;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SubscriptionService {
+	@Autowired
+	SubscriptionRepository subscriptionRepository;
+	
+	private final ExternalApiUtil externalApiUtil;
+	
+	private static final String BASE_URL = "http://54.167.85.125:9090/";
+
+	@Transactional
+	public boolean selectAndCancel(SubscriptionSelectDTO subscriptionSelectDTO) {
+		SubscriptionHistDTO subscriptionHistDTO = subscriptionRepository.select(subscriptionSelectDTO);
+		System.out.println(subscriptionHistDTO);
+//		String url = BASE_URL + "/api/project/cancel/" + subscriptionHistDTO.getShId();
+//		try {
+//			externalApiUtil.callApi(url, HttpMethod.POST, subscriptionHistDTO, new ParameterizedTypeReference<ApiResponse<Void>>() {});
+//			log.info("[Service] 증권사 청약 취소 완료");
+//		} catch (RuntimeException e) {
+//			// 유틸리티에서 던진 구체적인 에러 메시지("잔액 부족" 등)가 이곳으로 전달됨
+//            log.error("[Service] 청약 취소 실패 사유: {}", e.getMessage());
+//            
+//            // 트랜잭션 롤백을 위해 예외를 다시 던지거나, 사용자 정의 예외로 변환
+//            throw e;
+//		}
+		return true;
+	}
+
+	
+}

--- a/src/main/java/com/animalfarm/mlf/domain/subscription/dto/SubscriptionHistDTO.java
+++ b/src/main/java/com/animalfarm/mlf/domain/subscription/dto/SubscriptionHistDTO.java
@@ -1,0 +1,42 @@
+package com.animalfarm.mlf.domain.subscription.dto;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class SubscriptionHistDTO {
+	private Long shId;                 // 청약 이력 고유 ID 
+    private Long projectId;            // 프로젝트 ID 
+    private Long userId;               // 투자자(개인/기업) ID
+    
+    private OffsetDateTime subscriptionDate; // 청약 신청 일시 
+    
+    private BigDecimal subscriptionAmount;   // 청약 금액
+    
+    // 청약 상태: PENDING, APPROVED, REJECTED, CANCELED
+    private String subscriptionStatus; 
+    
+    // 결제 상태: RESERVED, PAID, FAILED, REFUNDED 
+    private String paymentStatus;      
+    
+    // 증권사 체결/주문번호
+    private String externalRefId;      
+    
+    private OffsetDateTime canceledAt; // 취소 일시 
+
+    // UI 출력을 위한 추가 필드 (필요 시 활용)
+    private String projectName;        // 프로젝트명 
+    private String userNickname;       // 투자자 닉네임
+}

--- a/src/main/java/com/animalfarm/mlf/domain/subscription/dto/SubscriptionSelectDTO.java
+++ b/src/main/java/com/animalfarm/mlf/domain/subscription/dto/SubscriptionSelectDTO.java
@@ -1,0 +1,19 @@
+package com.animalfarm.mlf.domain.subscription.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class SubscriptionSelectDTO {
+	Long projectId;
+	Long userId; 
+}

--- a/src/main/resources/mybatis/mappers/SubscriptionMapper.xml
+++ b/src/main/resources/mybatis/mappers/SubscriptionMapper.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper	namespace="com.animalfarm.mlf.domain.subscription.SubscriptionRepository">
+	
+	<select id="select" parameterType="subscriptionSelectDTO" resultType="subscriptionHistDTO">
+		select * from subscription_hists
+		where project_id=#{projectId} and user_id=#{userId}
+	</select>
+	
+
+</mapper>

--- a/src/main/resources/mybatis/sqlMapConfig.xml
+++ b/src/main/resources/mybatis/sqlMapConfig.xml
@@ -31,6 +31,10 @@
 			alias="projectInsertDTO" />
 		<typeAlias type="com.animalfarm.mlf.domain.token.dto.TokenDTO"
 			alias="tokenDTO" />
+		<typeAlias type="com.animalfarm.mlf.domain.subscription.dto.SubscriptionSelectDTO"
+			alias="subscriptionSelectDTO" />
+		<typeAlias type="com.animalfarm.mlf.domain.subscription.dto.SubscriptionHistDTO"
+			alias="subscriptionHistDTO" />
 	</typeAliases>
 	
 </configuration>


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- 공통으로 사용할 ApiResponse와 ExternalApiUtil 생성
- 컨트롤러, 서비스, 레포지토리, 매퍼 추가

## 📝 변경 사항 (Key Changes)
- [x] 컨트롤러, 서비스, 레포지토리, 매퍼 추가

## 📸 스크린샷 (Screenshots / Demos)
| Feature | Screenshot |
| :--- | :--- |
| 컨트롤러 임시 테스트 | <img width="1038" height="1299" alt="image" src="https://github.com/user-attachments/assets/b8121b23-c672-4a75-8973-791851e68573" /> |

## 🔗 연관된 이슈 (Related Issues)
- 없음

## 🧐 주요 리뷰 포인트 (Review Point)
- ExternalApiUti;

## ✅ 최종 PR전 체크 리스트 (Checklist)
- [x] 코딩 컨벤션(Checkstyle)을 준수하였는가?
- [x] 불필요한 주석이나 시스템 로그(console.log, print)를 제거하였는가?
- [x] 변경 사항에 대한 테스트를 완료하였는가?
- [x] 관련 문서를 업데이트하였는가?