### PR TITLE
[FEAT] 강황증권에 토큰 발급 정보 API 전송 및 청약 신청 완료

### DIFF
--- a/src/main/java/com/animalfarm/mlf/common/JwtProvider.java
+++ b/src/main/java/com/animalfarm/mlf/common/JwtProvider.java
@@ -47,7 +47,7 @@ public class JwtProvider {
 	private final long refreshTokenExp = 14L * 24 * 60 * 60 * 1000L; //14일
 	
 
-	
+
 	@PostConstruct
 	protected void init() {
 		//시크릿 키를 HMAC SHA 알고리즘에 적합한 Key 객체로 변환

--- a/src/main/java/com/animalfarm/mlf/domain/project/ProjectBatchScheduler.java
+++ b/src/main/java/com/animalfarm/mlf/domain/project/ProjectBatchScheduler.java
@@ -16,10 +16,5 @@ public class ProjectBatchScheduler {
 	@Scheduled(cron = "0 * * * * *")
 	public void runBatch() {
 		List<ProjectStatusDTO> status = projectService.selectStatus();
-		System.out.println("#########결과########");
-		for (ProjectStatusDTO dto : status) {
-			System.out.println(dto);
-		}
-		System.out.println("\n\n\n");
 	}
 }

--- a/src/main/java/com/animalfarm/mlf/domain/project/ProjectController.java
+++ b/src/main/java/com/animalfarm/mlf/domain/project/ProjectController.java
@@ -22,6 +22,9 @@ import com.animalfarm.mlf.domain.project.dto.ProjectPictureDTO;
 import com.animalfarm.mlf.domain.project.dto.ProjectSearchReqDTO;
 import com.animalfarm.mlf.domain.project.dto.ProjectStarredDTO;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @RestController
 public class ProjectController {
 	@Autowired
@@ -84,7 +87,13 @@ public class ProjectController {
 	public ResponseEntity<String> insertProject(@RequestBody
 	ProjectInsertDTO projectInsertDTO) {
 		if (projectService.insertProject(projectInsertDTO)) {
-			return ResponseEntity.ok("success");
+			try {
+				projectService.postTokenIssue(projectInsertDTO);
+				return ResponseEntity.ok("success");
+			} catch (Exception e) {
+				log.error("증권사 전송 중 오류 발생: {}", e.getMessage());
+				return ResponseEntity.ok("api_fail");
+			}
 		} else {
 			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("프로젝트 등록 중 서버 오류가 발생했습니다.");
 		}

--- a/src/main/java/com/animalfarm/mlf/domain/project/ProjectService.java
+++ b/src/main/java/com/animalfarm/mlf/domain/project/ProjectService.java
@@ -235,7 +235,7 @@ public class ProjectService {
 
 	public Double selectMyWallet() {
 		// 1. 목적지 주소 생성 (외부 IP + 상세 경로)
-		String targetUrl = khUrl + "api/my/wallet/1";
+		String targetUrl = khUrl + "api/my/wallet/2";
 		try {
 			// 2. GET 방식으로 데이터 요청 (응답은 String으로 받는 예시)
 			ResponseEntity<ApiResponse> responseEntity = restTemplate.getForEntity(targetUrl, ApiResponse.class);

--- a/src/main/java/com/animalfarm/mlf/domain/project/ProjectService.java
+++ b/src/main/java/com/animalfarm/mlf/domain/project/ProjectService.java
@@ -8,13 +8,16 @@ import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.dao.DataAccessException;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
 import com.animalfarm.mlf.common.http.ApiResponse;
+import com.animalfarm.mlf.common.http.ExternalApiUtil;
 import com.animalfarm.mlf.domain.project.dto.FarmDTO;
 import com.animalfarm.mlf.domain.project.dto.ImgEditable;
 import com.animalfarm.mlf.domain.project.dto.ProjectDTO;
@@ -27,8 +30,12 @@ import com.animalfarm.mlf.domain.project.dto.ProjectSearchReqDTO;
 import com.animalfarm.mlf.domain.project.dto.ProjectStarredDTO;
 import com.animalfarm.mlf.domain.project.dto.ProjectStatusDTO;
 import com.animalfarm.mlf.domain.token.TokenRepository;
+import com.animalfarm.mlf.domain.token.dto.TokenIssueDTO;
+
+import lombok.extern.slf4j.Slf4j;
 
 @Service
+@Slf4j
 public class ProjectService {
 	@Autowired
 	ProjectRepository projectRepository;
@@ -42,6 +49,9 @@ public class ProjectService {
 
 	@Autowired
 	private RestTemplate restTemplate;
+
+	@Autowired
+	ExternalApiUtil externalApiUtil;
 
 	public List<ProjectDTO> selectAll() {
 		return projectRepository.selectAll();
@@ -104,7 +114,7 @@ public class ProjectService {
 				.fromUserId(null) // [요구사항 1-3] 보낸 사용자 null
 				.toUserId(1L) // [요구사항 1-2] 시스템 관리자(1)에게 배정
 				.transactionId(txId) // 거래 고유 식별 번호
-				.externalRefId(txId) // 증권사 참조 ID (일단 동일하게 세팅)
+				.externalRefId(990803L) // 증권사 참조 ID (일단 동일하게 세팅)
 				.orderAmount(totalSupply) // [요구사항 1-1] 전체 토큰 지분
 				.contractAmount(totalSupply) // 발행 시 체결 수량은 전체 수량과 동일
 				.status("COMPLETED") // 발행 완료 상태
@@ -250,6 +260,28 @@ public class ProjectService {
 			// 3. 외부 서버 연결 실패 시 예외 처리 (재시도 테이블 insert 등)
 			System.err.println("외부 서버 통신 실패: " + e.getMessage());
 			return 0.0;
+		}
+	}
+
+	public void postTokenIssue(ProjectInsertDTO projectInsertDTO) {
+		TokenIssueDTO tokenIssueDTO = TokenIssueDTO.builder()
+			.tokenName(projectInsertDTO.getProjectName())
+			.tickerSymbol(projectInsertDTO.getTickerSymbol())
+			.totalSupply(projectInsertDTO.getTotalSupply())
+			.projectId(projectInsertDTO.getProjectId())
+			.issuePrice(projectInsertDTO.getTargetAmount().divide(projectInsertDTO.getTotalSupply()))
+			.createdAt(projectInsertDTO.getCreatedAt())
+			.build();
+
+		String targetUrl = khUrl + "api/project/open";
+		try {
+			TokenIssueDTO result = externalApiUtil.callApi(targetUrl, HttpMethod.POST, tokenIssueDTO,
+				new ParameterizedTypeReference<ApiResponse<TokenIssueDTO>>() {});
+			log.info("증권사 정송 성공 : " + result);
+		} catch (Exception e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+			log.error("실패!!! : " + e.getMessage());
 		}
 	}
 }

--- a/src/main/java/com/animalfarm/mlf/domain/project/ProjectService.java
+++ b/src/main/java/com/animalfarm/mlf/domain/project/ProjectService.java
@@ -233,9 +233,9 @@ public class ProjectService {
 		}
 	}
 
-	public Double selectMyWallet() {
+	public Double selectMyWalletAmount() {
 		// 1. 목적지 주소 생성 (외부 IP + 상세 경로)
-		String targetUrl = khUrl + "api/my/wallet/2";
+		String targetUrl = khUrl + "api/my/wallet/1";
 		try {
 			// 2. GET 방식으로 데이터 요청 (응답은 String으로 받는 예시)
 			ResponseEntity<ApiResponse> responseEntity = restTemplate.getForEntity(targetUrl, ApiResponse.class);

--- a/src/main/java/com/animalfarm/mlf/domain/project/ProjectViewController.java
+++ b/src/main/java/com/animalfarm/mlf/domain/project/ProjectViewController.java
@@ -26,7 +26,7 @@ public class ProjectViewController {
 	Long id, Model model) {
 		model.addAttribute("projectData", projectService.selectDetail(id));
 		model.addAttribute("contentPage", "/WEB-INF/views/project/project_detail.jsp");
-		model.addAttribute("myCash", projectService.selectMyWallet());
+		model.addAttribute("myCash", projectService.selectMyWalletAmount());
 		return "layout";
 	}
 

--- a/src/main/java/com/animalfarm/mlf/domain/project/dto/ProjectDetailDTO.java
+++ b/src/main/java/com/animalfarm/mlf/domain/project/dto/ProjectDetailDTO.java
@@ -51,4 +51,5 @@ public class ProjectDetailDTO {
 
 	private String tickerSymbol; //Tokens 테이블 연관
 	private BigDecimal totalSupply;
+	private Long tokenId;
 }

--- a/src/main/java/com/animalfarm/mlf/domain/project/dto/ProjectInsertDTO.java
+++ b/src/main/java/com/animalfarm/mlf/domain/project/dto/ProjectInsertDTO.java
@@ -6,6 +6,8 @@ import java.util.List;
 
 import org.springframework.format.annotation.DateTimeFormat;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -61,6 +63,9 @@ public class ProjectInsertDTO implements ImgEditable {
 	private String tickerSymbol;
 	private BigDecimal totalSupply;
 	private Long tokenId;
+
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+	private OffsetDateTime createdAt;
 
 	// 이미지 파일명 리스트와 삭제할 ID 리스트
 	private List<String> projectImageNames; // 신규 추가된 파일명들

--- a/src/main/java/com/animalfarm/mlf/domain/project/dto/ProjectNewTokenDTO.java
+++ b/src/main/java/com/animalfarm/mlf/domain/project/dto/ProjectNewTokenDTO.java
@@ -25,7 +25,7 @@ public class ProjectNewTokenDTO {
 
 	// 3. 거래 및 주문 정보
 	private String transactionId; // 거래 고유 식별 번호 (VARCHAR(20))
-	private String externalRefId; // 증권사 체결/주문 번호 (VARCHAR(20))
+	private Long externalRefId; // 증권사 체결/주문 번호 (VARCHAR(20))
 	private BigDecimal orderAmount; // 주문 수량 (DECIMAL(20,4))
 	private BigDecimal contractAmount;// 체결 수량 (DECIMAL(20,4))
 

--- a/src/main/java/com/animalfarm/mlf/domain/subscription/SubscriptionController.java
+++ b/src/main/java/com/animalfarm/mlf/domain/subscription/SubscriptionController.java
@@ -8,26 +8,35 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.animalfarm.mlf.common.http.ApiResponse;
+import com.animalfarm.mlf.domain.subscription.dto.SubscriptionInsertDTO;
 import com.animalfarm.mlf.domain.subscription.dto.SubscriptionSelectDTO;
 
 @RestController
 @RequestMapping("/api/subscription")
 public class SubscriptionController {
-	
+
 	@Autowired
 	SubscriptionService subscriptionService;
-	
+
 	@PostMapping("/cancel")
-	public ResponseEntity<ApiResponse<Object>> cancelSubscription (@RequestBody SubscriptionSelectDTO subscriptionSelectDTO) {
+	public ResponseEntity<ApiResponse<Object>> cancelSubscription(@RequestBody
+	SubscriptionSelectDTO subscriptionSelectDTO) {
 		boolean isSuccess = subscriptionService.selectAndCancel(subscriptionSelectDTO);
-		
+
 		if (isSuccess) {
-            // 디자인 가이드에 따른 성공 메시지 반환
-            return ResponseEntity.ok(ApiResponse.message("청약 취소가 완료되었습니다."));
-        } else {
-            // 실패 시 처리
-            return ResponseEntity.badRequest().body(ApiResponse.message("청약 취소에 실패했습니다. 내역을 확인해주세요."));
-        }
+			// 디자인 가이드에 따른 성공 메시지 반환
+			return ResponseEntity.ok(ApiResponse.message("청약 취소가 완료되었습니다."));
+		} else {
+			// 실패 시 처리
+			return ResponseEntity.badRequest().body(ApiResponse.message("청약 취소에 실패했습니다. 내역을 확인해주세요."));
+		}
 	}
-	
+
+	@PostMapping("/application")
+	public ResponseEntity<ApiResponse<Object>> applicationSubscription(@RequestBody
+	SubscriptionInsertDTO subscriptionInsertDTO) {
+		subscriptionService.subscriptionApplication(subscriptionInsertDTO);
+		return ResponseEntity.ok(ApiResponse.message("청약 취소가 완료되었습니다."));
+	}
+
 }

--- a/src/main/java/com/animalfarm/mlf/domain/subscription/SubscriptionController.java
+++ b/src/main/java/com/animalfarm/mlf/domain/subscription/SubscriptionController.java
@@ -1,6 +1,7 @@
 package com.animalfarm.mlf.domain.subscription;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -11,6 +12,9 @@ import com.animalfarm.mlf.common.http.ApiResponse;
 import com.animalfarm.mlf.domain.subscription.dto.SubscriptionInsertDTO;
 import com.animalfarm.mlf.domain.subscription.dto.SubscriptionSelectDTO;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @RestController
 @RequestMapping("/api/subscription")
 public class SubscriptionController {
@@ -33,10 +37,20 @@ public class SubscriptionController {
 	}
 
 	@PostMapping("/application")
-	public ResponseEntity<ApiResponse<Object>> applicationSubscription(@RequestBody
+	public ResponseEntity<String> applicationSubscription(@RequestBody
 	SubscriptionInsertDTO subscriptionInsertDTO) {
-		subscriptionService.subscriptionApplication(subscriptionInsertDTO);
-		return ResponseEntity.ok(ApiResponse.message("청약 취소가 완료되었습니다."));
+		if(subscriptionService.subscriptionApplication(subscriptionInsertDTO)) {
+			try {
+				subscriptionService.postApplication(subscriptionInsertDTO);
+				log.info("여기 왔어");
+				return ResponseEntity.ok("success");
+			} catch (Exception e) {
+				log.error("증권사 전송 중 오류 발생: {}", e.getMessage());
+				return ResponseEntity.ok("api_fail");
+			}
+		} else {
+			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("청약 신청 중 서버 오류가 발생했습니다.");
+		}
 	}
 
 }

--- a/src/main/java/com/animalfarm/mlf/domain/subscription/SubscriptionController.java
+++ b/src/main/java/com/animalfarm/mlf/domain/subscription/SubscriptionController.java
@@ -39,13 +39,15 @@ public class SubscriptionController {
 	@PostMapping("/application")
 	public ResponseEntity<String> applicationSubscription(@RequestBody
 	SubscriptionInsertDTO subscriptionInsertDTO) {
-		if(subscriptionService.subscriptionApplication(subscriptionInsertDTO)) {
+		if (subscriptionService.subscriptionApplication(subscriptionInsertDTO)) {
 			try {
 				subscriptionService.postApplication(subscriptionInsertDTO);
-				log.info("여기 왔어");
 				return ResponseEntity.ok("success");
 			} catch (Exception e) {
 				log.error("증권사 전송 중 오류 발생: {}", e.getMessage());
+				if ("empty_payload".equals(e.getMessage())) {
+					return ResponseEntity.ok("empty_payload");
+				}
 				return ResponseEntity.ok("api_fail");
 			}
 		} else {

--- a/src/main/java/com/animalfarm/mlf/domain/subscription/SubscriptionRepository.java
+++ b/src/main/java/com/animalfarm/mlf/domain/subscription/SubscriptionRepository.java
@@ -3,10 +3,13 @@ package com.animalfarm.mlf.domain.subscription;
 import org.apache.ibatis.annotations.Mapper;
 
 import com.animalfarm.mlf.domain.subscription.dto.SubscriptionHistDTO;
+import com.animalfarm.mlf.domain.subscription.dto.SubscriptionInsertDTO;
 import com.animalfarm.mlf.domain.subscription.dto.SubscriptionSelectDTO;
 
 @Mapper
 public interface SubscriptionRepository {
-	
+
 	public abstract SubscriptionHistDTO select(SubscriptionSelectDTO subscriptionSelectDTO);
+
+	public abstract boolean subscriptionApplication(SubscriptionInsertDTO subscriptionInsertDTO);
 }

--- a/src/main/java/com/animalfarm/mlf/domain/subscription/SubscriptionRepository.java
+++ b/src/main/java/com/animalfarm/mlf/domain/subscription/SubscriptionRepository.java
@@ -12,4 +12,8 @@ public interface SubscriptionRepository {
 	public abstract SubscriptionHistDTO select(SubscriptionSelectDTO subscriptionSelectDTO);
 
 	public abstract boolean subscriptionApplication(SubscriptionInsertDTO subscriptionInsertDTO);
+
+	public abstract boolean subscriptionApplicationResponse(SubscriptionInsertDTO subscriptionInsertDTO);
+
+	public abstract boolean updatePlusAmount(SubscriptionInsertDTO subscriptionInsertDTO);
 }

--- a/src/main/java/com/animalfarm/mlf/domain/subscription/SubscriptionRepository.java
+++ b/src/main/java/com/animalfarm/mlf/domain/subscription/SubscriptionRepository.java
@@ -16,4 +16,6 @@ public interface SubscriptionRepository {
 	public abstract boolean subscriptionApplicationResponse(SubscriptionInsertDTO subscriptionInsertDTO);
 
 	public abstract boolean updatePlusAmount(SubscriptionInsertDTO subscriptionInsertDTO);
+
+	public abstract Long selectUclId(SubscriptionInsertDTO subscriptionInsertDTO);
 }

--- a/src/main/java/com/animalfarm/mlf/domain/subscription/SubscriptionService.java
+++ b/src/main/java/com/animalfarm/mlf/domain/subscription/SubscriptionService.java
@@ -2,17 +2,16 @@ package com.animalfarm.mlf.domain.subscription;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
 
 import com.animalfarm.mlf.common.http.ApiResponse;
 import com.animalfarm.mlf.common.http.ExternalApiUtil;
 import com.animalfarm.mlf.domain.subscription.dto.SubscriptionHistDTO;
 import com.animalfarm.mlf.domain.subscription.dto.SubscriptionInsertDTO;
 import com.animalfarm.mlf.domain.subscription.dto.SubscriptionSelectDTO;
-import com.animalfarm.mlf.domain.token.dto.TokenIssueDTO;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,14 +23,17 @@ public class SubscriptionService {
 	@Autowired
 	SubscriptionRepository subscriptionRepository;
 
+	@Autowired
+	private RestTemplate restTemplate;
+
 	private final ExternalApiUtil externalApiUtil;
 
 	private static final String BASE_URL = "http://54.167.85.125:9090/";
-	
+
 	// 강황증권 API 서버 주소
 	@Value("${api.kh-stock.url}")
 	private String khUrl;
-	
+
 	@Transactional
 	public boolean selectAndCancel(SubscriptionSelectDTO subscriptionSelectDTO) {
 		SubscriptionHistDTO subscriptionHistDTO = subscriptionRepository.select(subscriptionSelectDTO);
@@ -53,17 +55,41 @@ public class SubscriptionService {
 	public boolean subscriptionApplication(SubscriptionInsertDTO subscriptionInsertDTO) {
 		return subscriptionRepository.subscriptionApplication(subscriptionInsertDTO);
 	}
-	
+
+	@Transactional
 	public void postApplication(SubscriptionInsertDTO subscriptionInsertDTO) {
 		Long tokenId = subscriptionInsertDTO.getTokenId();
-		String targetUrl = khUrl + "api/project/application/" + tokenId;
+		// 1. 증권사 명세서 규격에 맞게 맵 구성
+		String targetUrl = khUrl + "api/project/application/" + tokenId
+			+ "?subscriptionId=" + 3 // 또는 dto.getShId()
+			+ "&walletId=" + 2 // 또는 dto.getUclId()
+			+ "&amount=" + subscriptionInsertDTO.getSubscriptionAmount();
 		try {
-			SubscriptionInsertDTO result = externalApiUtil.callApi(targetUrl, HttpMethod.POST, subscriptionInsertDTO,
-					new ParameterizedTypeReference<ApiResponse<SubscriptionInsertDTO>>() {});
-			log.info("증권사 정송 성공 : " + result);
+			// 2. restTemplate으로 직접 호출 (껍데기 ApiResponse.class를 지정)
+			ResponseEntity<ApiResponse> responseEntity = restTemplate.postForEntity(targetUrl, null, ApiResponse.class);
+
+			int status = responseEntity.getStatusCodeValue();
+			if (status == 200) {
+				ApiResponse response = responseEntity.getBody();
+
+				// 3. 드디어 message와 payload를 둘 다 꺼낼 수 있습니다!
+				String msg = response.getMessage(); // "청약 신청이 완료되었습니다."
+				Object payload = response.getPayload();
+
+				System.out.println("증권사 메시지: " + msg);
+				System.out.println("트랜잭션 ID: " + payload);
+				if (payload != null) {
+					subscriptionInsertDTO.setPaymentStatus("PAID");
+					subscriptionInsertDTO.setExternalRefId((Long)payload);
+					subscriptionRepository.subscriptionApplicationResponse(subscriptionInsertDTO);
+					subscriptionRepository.updatePlusAmount(subscriptionInsertDTO);
+				} else {
+					subscriptionInsertDTO.setPaymentStatus("FAILED");
+					subscriptionRepository.subscriptionApplicationResponse(subscriptionInsertDTO);
+				}
+			}
 		} catch (Exception e) {
-			e.printStackTrace();
-			log.error("실패!!! : " + e.getMessage());
+			System.out.println("통신 실패: " + e.getMessage());
 		}
 	}
 

--- a/src/main/java/com/animalfarm/mlf/domain/subscription/SubscriptionService.java
+++ b/src/main/java/com/animalfarm/mlf/domain/subscription/SubscriptionService.java
@@ -89,7 +89,7 @@ public class SubscriptionService {
 				Long uclId = subscriptionRepository.selectUclId(subscriptionInsertDTO);
 
 				System.out.println("증권사 메시지: " + msg);
-				System.out.println("트랜잭션 ID: " + payload);
+				System.out.println("payload: " + payload);
 				if (payload != null) {
 					subscriptionInsertDTO.setPaymentStatus("PAID");
 					subscriptionInsertDTO.setExternalRefId((Long)payload);
@@ -98,10 +98,12 @@ public class SubscriptionService {
 				} else {
 					subscriptionInsertDTO.setPaymentStatus("FAILED");
 					subscriptionRepository.subscriptionApplicationResponse(subscriptionInsertDTO);
+					throw new RuntimeException("empty_payload");
 				}
 			}
 		} catch (Exception e) {
 			System.out.println("통신 실패: " + e.getMessage());
+			throw e;
 		}
 	}
 

--- a/src/main/java/com/animalfarm/mlf/domain/subscription/SubscriptionService.java
+++ b/src/main/java/com/animalfarm/mlf/domain/subscription/SubscriptionService.java
@@ -1,5 +1,7 @@
 package com.animalfarm.mlf.domain.subscription;
 
+import java.math.BigDecimal;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
@@ -53,17 +55,25 @@ public class SubscriptionService {
 	}
 
 	public boolean subscriptionApplication(SubscriptionInsertDTO subscriptionInsertDTO) {
+		//Long userId = SecurityUtil.getCurrentUserId();
+		//subscriptionInsertDTO.setUserId(userId);
 		return subscriptionRepository.subscriptionApplication(subscriptionInsertDTO);
 	}
 
 	@Transactional
 	public void postApplication(SubscriptionInsertDTO subscriptionInsertDTO) {
 		Long tokenId = subscriptionInsertDTO.getTokenId();
+		Long shId = subscriptionInsertDTO.getShId();
+		BigDecimal amount = subscriptionInsertDTO.getSubscriptionAmount();
+		System.out.println(subscriptionInsertDTO);
+		//Long userId = SecurityUtil.getCurrentUserId();
+		//System.out.println(userId);
+		//subscriptionInsertDTO.setUserId(userId);
 		// 1. 증권사 명세서 규격에 맞게 맵 구성
 		String targetUrl = khUrl + "api/project/application/" + tokenId
-			+ "?subscriptionId=" + 3 // 또는 dto.getShId()
+			+ "?subscriptionId=" + shId
 			+ "&walletId=" + 2 // 또는 dto.getUclId()
-			+ "&amount=" + subscriptionInsertDTO.getSubscriptionAmount();
+			+ "&amount=" + amount;
 		try {
 			// 2. restTemplate으로 직접 호출 (껍데기 ApiResponse.class를 지정)
 			ResponseEntity<ApiResponse> responseEntity = restTemplate.postForEntity(targetUrl, null, ApiResponse.class);
@@ -75,6 +85,8 @@ public class SubscriptionService {
 				// 3. 드디어 message와 payload를 둘 다 꺼낼 수 있습니다!
 				String msg = response.getMessage(); // "청약 신청이 완료되었습니다."
 				Object payload = response.getPayload();
+
+				Long uclId = subscriptionRepository.selectUclId(subscriptionInsertDTO);
 
 				System.out.println("증권사 메시지: " + msg);
 				System.out.println("트랜잭션 ID: " + payload);

--- a/src/main/java/com/animalfarm/mlf/domain/subscription/SubscriptionService.java
+++ b/src/main/java/com/animalfarm/mlf/domain/subscription/SubscriptionService.java
@@ -1,16 +1,12 @@
 package com.animalfarm.mlf.domain.subscription;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpMethod;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.animalfarm.mlf.common.http.ApiResponse;
 import com.animalfarm.mlf.common.http.ExternalApiUtil;
 import com.animalfarm.mlf.domain.subscription.dto.SubscriptionHistDTO;
+import com.animalfarm.mlf.domain.subscription.dto.SubscriptionInsertDTO;
 import com.animalfarm.mlf.domain.subscription.dto.SubscriptionSelectDTO;
 
 import lombok.RequiredArgsConstructor;
@@ -22,28 +18,31 @@ import lombok.extern.slf4j.Slf4j;
 public class SubscriptionService {
 	@Autowired
 	SubscriptionRepository subscriptionRepository;
-	
+
 	private final ExternalApiUtil externalApiUtil;
-	
+
 	private static final String BASE_URL = "http://54.167.85.125:9090/";
 
 	@Transactional
 	public boolean selectAndCancel(SubscriptionSelectDTO subscriptionSelectDTO) {
 		SubscriptionHistDTO subscriptionHistDTO = subscriptionRepository.select(subscriptionSelectDTO);
 		System.out.println(subscriptionHistDTO);
-//		String url = BASE_URL + "/api/project/cancel/" + subscriptionHistDTO.getShId();
-//		try {
-//			externalApiUtil.callApi(url, HttpMethod.POST, subscriptionHistDTO, new ParameterizedTypeReference<ApiResponse<Void>>() {});
-//			log.info("[Service] 증권사 청약 취소 완료");
-//		} catch (RuntimeException e) {
-//			// 유틸리티에서 던진 구체적인 에러 메시지("잔액 부족" 등)가 이곳으로 전달됨
-//            log.error("[Service] 청약 취소 실패 사유: {}", e.getMessage());
-//            
-//            // 트랜잭션 롤백을 위해 예외를 다시 던지거나, 사용자 정의 예외로 변환
-//            throw e;
-//		}
+		//		String url = BASE_URL + "/api/project/cancel/" + subscriptionHistDTO.getShId();
+		//		try {
+		//			externalApiUtil.callApi(url, HttpMethod.POST, subscriptionHistDTO, new ParameterizedTypeReference<ApiResponse<Void>>() {});
+		//			log.info("[Service] 증권사 청약 취소 완료");
+		//		} catch (RuntimeException e) {
+		//			// 유틸리티에서 던진 구체적인 에러 메시지("잔액 부족" 등)가 이곳으로 전달됨
+		//            log.error("[Service] 청약 취소 실패 사유: {}", e.getMessage());
+		//
+		//            // 트랜잭션 롤백을 위해 예외를 다시 던지거나, 사용자 정의 예외로 변환
+		//            throw e;
+		//		}
 		return true;
 	}
 
-	
+	public boolean subscriptionApplication(SubscriptionInsertDTO subscriptionInsertDTO) {
+		return subscriptionRepository.subscriptionApplication(subscriptionInsertDTO);
+	}
+
 }

--- a/src/main/java/com/animalfarm/mlf/domain/subscription/dto/SubscriptionInsertDTO.java
+++ b/src/main/java/com/animalfarm/mlf/domain/subscription/dto/SubscriptionInsertDTO.java
@@ -19,13 +19,14 @@ public class SubscriptionInsertDTO {
 	private Long shId;
 	private Long projectId;
 	private Long userId;
-	private BigDecimal amount;
+	private BigDecimal subscriptionAmount;
 
 	// 청약 상태: PENDING, APPROVED, REJECTED, CANCELED
 	private String subscriptionStatus;
 
 	// 결제 상태: RESERVED, PAID, FAILED, REFUNDED
 	private String paymentStatus;
+	private Long externalRefId;
 
 	// kh증권의 wallet_id
 	private Long uclId;

--- a/src/main/java/com/animalfarm/mlf/domain/subscription/dto/SubscriptionInsertDTO.java
+++ b/src/main/java/com/animalfarm/mlf/domain/subscription/dto/SubscriptionInsertDTO.java
@@ -19,7 +19,7 @@ public class SubscriptionInsertDTO {
 	private Long shId;
 	private Long projectId;
 	private Long userId;
-	private BigDecimal subscriptionAmount;
+	private BigDecimal amount;
 
 	// 청약 상태: PENDING, APPROVED, REJECTED, CANCELED
 	private String subscriptionStatus;
@@ -29,4 +29,5 @@ public class SubscriptionInsertDTO {
 
 	// kh증권의 wallet_id
 	private Long uclId;
+	private Long tokenId;
 }

--- a/src/main/java/com/animalfarm/mlf/domain/subscription/dto/SubscriptionInsertDTO.java
+++ b/src/main/java/com/animalfarm/mlf/domain/subscription/dto/SubscriptionInsertDTO.java
@@ -1,0 +1,32 @@
+package com.animalfarm.mlf.domain.subscription.dto;
+
+import java.math.BigDecimal;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class SubscriptionInsertDTO {
+	private Long shId;
+	private Long projectId;
+	private Long userId;
+	private BigDecimal subscriptionAmount;
+
+	// 청약 상태: PENDING, APPROVED, REJECTED, CANCELED
+	private String subscriptionStatus;
+
+	// 결제 상태: RESERVED, PAID, FAILED, REFUNDED
+	private String paymentStatus;
+
+	// kh증권의 wallet_id
+	private Long uclId;
+}

--- a/src/main/java/com/animalfarm/mlf/domain/token/dto/TokenIssueDTO.java
+++ b/src/main/java/com/animalfarm/mlf/domain/token/dto/TokenIssueDTO.java
@@ -1,10 +1,27 @@
 package com.animalfarm.mlf.domain.token.dto;
 
 import java.math.BigDecimal;
+import java.time.OffsetDateTime;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class TokenIssueDTO {
 	private String tokenName;
 	private String tickerSymbol;
 	private BigDecimal totalSupply;
 	private Long projectId;
+	private BigDecimal issuePrice;
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+	private OffsetDateTime createdAt;
 }

--- a/src/main/resources/mybatis/mappers/ProjectMapper.xml
+++ b/src/main/resources/mybatis/mappers/ProjectMapper.xml
@@ -46,6 +46,7 @@
 		c.method,
 		t.ticker_symbol,
 		t.total_supply,
+		t.token_id,
 		img.image_url, -- 직접 조인 (중복 행 발생하지만 MyBatis가 처리함)
 		fed.temperature_inside -- 직접 조인
 		FROM projects p

--- a/src/main/resources/mybatis/mappers/ProjectMapper.xml
+++ b/src/main/resources/mybatis/mappers/ProjectMapper.xml
@@ -143,7 +143,7 @@
 		#{managerCount})
 	</insert>
 
-	<insert id="insertToken" parameterType="projectInsertDTO" useGeneratedKeys="true" keyProperty="tokenId" keyColumn="token_id">		
+	<insert id="insertToken" parameterType="projectInsertDTO" useGeneratedKeys="true" keyProperty="tokenId,createdAt" keyColumn="token_id,created_at">		
 		INSERT INTO tokens (project_id, token_name, ticker_symbol, total_supply)
 		Values (
 		#{projectId},

--- a/src/main/resources/mybatis/mappers/SubscriptionMapper.xml
+++ b/src/main/resources/mybatis/mappers/SubscriptionMapper.xml
@@ -10,5 +10,18 @@
 		where project_id=#{projectId} and user_id=#{userId}
 	</select>
 	
-
+	<insert id="subscriptionApplication" parameterType="subscriptionApplication">
+		insert into subscription_hists (
+		project_id, 
+		user_id, 
+		subscription_amount, 
+		subscription_status, 
+		payment_status)
+		values(
+		#{projectId}, 
+		415, 
+		#{subscriptionAmount}, 
+		'PENDING', 
+		'RESERVED')
+	</insert>
 </mapper>

--- a/src/main/resources/mybatis/mappers/SubscriptionMapper.xml
+++ b/src/main/resources/mybatis/mappers/SubscriptionMapper.xml
@@ -6,8 +6,7 @@
 <mapper
 	namespace="com.animalfarm.mlf.domain.subscription.SubscriptionRepository">
 
-	<select id="select" parameterType="subscriptionSelectDTO"
-		resultType="subscriptionHistDTO">
+	<select id="select" parameterType="subscriptionSelectDTO" resultType="subscriptionHistDTO">
 		select * from subscription_hists
 		where
 		project_id=#{projectId} and user_id=#{userId}
@@ -23,7 +22,7 @@
 		payment_status)
 		values(
 		#{projectId},
-		2,
+		5,
 		#{subscriptionAmount},
 		'PENDING',
 		'RESERVED')
@@ -39,4 +38,9 @@
 	<update id="updatePlusAmount" parameterType="subscriptionApplication">
 		update projects set actual_amount = actual_amount + #{subscriptionAmount} where project_id = #{projectId}
 	</update>
+	
+	<select id="selectUclId" resultType="Long">
+		select ucl.ucl_id  from users u join user_certificate_links ucl on u.user_id = ucl.user_id 
+		where u.user_id = #{userId};
+	</select>
 </mapper>

--- a/src/main/resources/mybatis/mappers/SubscriptionMapper.xml
+++ b/src/main/resources/mybatis/mappers/SubscriptionMapper.xml
@@ -3,25 +3,40 @@
     PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
     "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
-<mapper	namespace="com.animalfarm.mlf.domain.subscription.SubscriptionRepository">
-	
-	<select id="select" parameterType="subscriptionSelectDTO" resultType="subscriptionHistDTO">
+<mapper
+	namespace="com.animalfarm.mlf.domain.subscription.SubscriptionRepository">
+
+	<select id="select" parameterType="subscriptionSelectDTO"
+		resultType="subscriptionHistDTO">
 		select * from subscription_hists
-		where project_id=#{projectId} and user_id=#{userId}
+		where
+		project_id=#{projectId} and user_id=#{userId}
 	</select>
-	
-	<insert id="subscriptionApplication" parameterType="subscriptionApplication">
+
+	<insert id="subscriptionApplication" parameterType="subscriptionApplication" useGeneratedKeys="true"
+		keyProperty="shId" keyColumn="sh_id">
 		insert into subscription_hists (
-		project_id, 
-		user_id, 
-		subscription_amount, 
-		subscription_status, 
+		project_id,
+		user_id,
+		subscription_amount,
+		subscription_status,
 		payment_status)
 		values(
-		#{projectId}, 
-		2, 
-		#{amount}, 
-		'PENDING', 
+		#{projectId},
+		2,
+		#{subscriptionAmount},
+		'PENDING',
 		'RESERVED')
 	</insert>
+
+	<update id="subscriptionApplicationResponse"
+		parameterType="subscriptionApplication">
+		update subscription_hists set payment_status =
+		#{paymentStatus}, external_ref_id = #{externalRefId} where sh_id =
+		#{shId}
+	</update>
+	
+	<update id="updatePlusAmount" parameterType="subscriptionApplication">
+		update projects set actual_amount = actual_amount + #{subscriptionAmount} where project_id = #{projectId}
+	</update>
 </mapper>

--- a/src/main/resources/mybatis/mappers/SubscriptionMapper.xml
+++ b/src/main/resources/mybatis/mappers/SubscriptionMapper.xml
@@ -19,8 +19,8 @@
 		payment_status)
 		values(
 		#{projectId}, 
-		415, 
-		#{subscriptionAmount}, 
+		2, 
+		#{amount}, 
 		'PENDING', 
 		'RESERVED')
 	</insert>

--- a/src/main/resources/mybatis/sqlMapConfig.xml
+++ b/src/main/resources/mybatis/sqlMapConfig.xml
@@ -37,6 +37,8 @@
 			alias="subscriptionSelectDTO" />
 		<typeAlias type="com.animalfarm.mlf.domain.subscription.dto.SubscriptionHistDTO"
 			alias="subscriptionHistDTO" />
+		<typeAlias type="com.animalfarm.mlf.domain.subscription.dto.SubscriptionInsertDTO"
+			alias="subscriptionApplication" />
 		<typeAlias type="com.animalfarm.mlf.domain.project.dto.ProjectNewTokenDTO"
 			alias="projectNewTokenDTO" />
 	</typeAliases>

--- a/src/main/webapp/WEB-INF/tags/subscription_modal.tag
+++ b/src/main/webapp/WEB-INF/tags/subscription_modal.tag
@@ -165,9 +165,9 @@
         
         const payload = {
         	tokenId: ${projectData.tokenId},
-        	subscriptionId: 33,         // 프로젝트 ID
-            amount: totalPrice, // 수량
-            walletId: 2L,
+        	projectId: projectId,         // 프로젝트 ID
+        	subscriptionAmount: totalPrice, // 수량
+            walletId: 2,
             projectId: projectId
             
         };
@@ -176,6 +176,31 @@
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(payload) // 박스를 테이프로 감싸서 전송!
+        })
+        .then(response => {
+            // 서버가 200 OK를 던졌는지 확인
+            if (!response.ok) {
+                return response.text().then(err => { throw new Error(err) });
+            }
+            return response.text(); // 서버가 ResponseEntity<String>으로 주니까 text로 받기
+        })
+        .then(result => {
+            // 앞뒤 공백 제거 (혹시 모를 줄바꿈 방지)
+            const status = result.trim();
+            console.log("서버 응답 결과:", status);
+
+            if (status === "success") {
+                alert("✅ 청약 신청이 완료되었습니다!");
+                location.href = ctx + "/project/" + projectId;
+            } else if (status === "api_fail") {
+                alert("❌ 증권사 통신 중 오류가 발생했습니다.");
+            } else {
+                alert("⚠️ 신청 실패: " + status);
+            }
+        })
+        .catch(error => {
+            console.error("Fetch 에러:", error);
+            alert("⚠️ 서버 연결 오류: " + error.message);
         });
     }
     

--- a/src/main/webapp/WEB-INF/tags/subscription_modal.tag
+++ b/src/main/webapp/WEB-INF/tags/subscription_modal.tag
@@ -192,8 +192,8 @@
             if (status === "success") {
                 alert("✅ 청약 신청이 완료되었습니다!");
                 location.href = ctx + "/project/" + projectId;
-            } else if (status === "api_fail") {
-                alert("❌ 증권사 통신 중 오류가 발생했습니다.");
+            } else if (status === "empty_payload") {
+                alert("❌ 청약 신청이 실패되었습니다!.");
             } else {
                 alert("⚠️ 신청 실패: " + status);
             }

--- a/src/main/webapp/WEB-INF/tags/subscription_modal.tag
+++ b/src/main/webapp/WEB-INF/tags/subscription_modal.tag
@@ -5,6 +5,7 @@
 <%-- 속성 정의 --%>
 <%@ attribute name="id" required="true" %> <%-- 모달 고유 ID --%>
 <%@ attribute name="title" required="true" %> <%-- 프로젝트 제목 --%>
+<%@ attribute name="projectId" required="true" %> <%-- 프로젝트 제목 --%>
 <%@ attribute name="price" required="true" type="java.lang.Long" %> <%-- 1토큰 당 가격 --%>
 <%@ attribute name="thumbnail" required="false" %> <%-- 이미지 경로 --%>
 <%@ attribute name="userLimit" required="true" type="java.lang.Long" %> <%-- 투자 한도 잔여 --%>
@@ -69,7 +70,7 @@
         </div>
 
         <%-- 신청 버튼 --%>
-        <button class="submit-btn" onclick="submitSubscription('${id}')">청약 신청 완료</button>
+        <button class="submit-btn" onclick="submitSubscription('${projectId}')">청약 신청 완료</button>
     </div>
 </div>
 
@@ -155,6 +156,25 @@
         alert(qty + "토큰 청약 신청이 완료되었습니다.");
         closeSubscriptionModal(id);
     }
+    
+ // '청약 신청 완료' 버튼을 눌렀을 때 실행되는 함수
+    function submitSubscription(projectId) {
+        const quantity = document.getElementById('sub-quantity').value; // 입력한 숫자
+        const totalPrice = quantity * unitPrice;
+        
+        const payload = {
+            projectId: projectId,         // 프로젝트 ID
+            subscriptionAmount: totalPrice, // 수량
+            userId: "${loginUser.id}"     // 세션에서 가져온 사용자 ID
+        };
+
+        fetch(ctx + "/api/subscription/application", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(payload) // 박스를 테이프로 감싸서 전송!
+        });
+    }
+    
     // 초기 실행
     window.onload = () => updateModalUI(1);
 </script>

--- a/src/main/webapp/WEB-INF/tags/subscription_modal.tag
+++ b/src/main/webapp/WEB-INF/tags/subscription_modal.tag
@@ -167,7 +167,7 @@
         	tokenId: ${projectData.tokenId},
         	projectId: projectId,         // 프로젝트 ID
         	subscriptionAmount: totalPrice, // 수량
-            walletId: 2,
+            walletId: 1,
             projectId: projectId
             
         };

--- a/src/main/webapp/WEB-INF/tags/subscription_modal.tag
+++ b/src/main/webapp/WEB-INF/tags/subscription_modal.tag
@@ -10,6 +10,7 @@
 <%@ attribute name="thumbnail" required="false" %> <%-- 이미지 경로 --%>
 <%@ attribute name="userLimit" required="true" type="java.lang.Long" %> <%-- 투자 한도 잔여 --%>
 <%@ attribute name="walletBalance" required="true" type="java.lang.Long" %> <%-- 지갑 잔액 --%>
+<%@ attribute name="tokenId" required="true" type="java.lang.Long" %> <%-- 토큰Id --%>
 
 <div id="${id}" class="subscription-modal-overlay">
     <div class="subscription-modal-content" onclick="event.stopPropagation()">
@@ -163,11 +164,14 @@
         const totalPrice = quantity * unitPrice;
         
         const payload = {
-            projectId: projectId,         // 프로젝트 ID
-            subscriptionAmount: totalPrice, // 수량
-            userId: "${loginUser.id}"     // 세션에서 가져온 사용자 ID
+        	tokenId: ${projectData.tokenId},
+        	subscriptionId: 33,         // 프로젝트 ID
+            amount: totalPrice, // 수량
+            walletId: 2L,
+            projectId: projectId
+            
         };
-
+        
         fetch(ctx + "/api/subscription/application", {
             method: "POST",
             headers: { "Content-Type": "application/json" },

--- a/src/main/webapp/WEB-INF/views/project/project_detail.jsp
+++ b/src/main/webapp/WEB-INF/views/project/project_detail.jsp
@@ -131,6 +131,7 @@
 		    thumbnail="${pageContext.request.contextPath}/uploads/projects/${projectData.images[0]}"
 		    userLimit="40000000"
 		    walletBalance="${myCash}"
+		    tokenId="${tokenId}"
 		/>
 		<t:warning_card id="noAccountModal" title="연동된 계좌 없음">
    			현재 팜조각에 연동된 <strong>증권사 계좌</strong>가 없습니다.<br> 

--- a/src/main/webapp/WEB-INF/views/project/project_detail.jsp
+++ b/src/main/webapp/WEB-INF/views/project/project_detail.jsp
@@ -126,7 +126,8 @@
 		<t:subscription_modal 
 		    id="subscriptionModal"
 		    title="${projectData.projectName} 공모"
-		    price="345000"
+		    projectId="${projectData.projectId}"
+		    price="${projectData.totalSupply > 0 ? (projectData.targetAmount / projectData.totalSupply) : 0}"
 		    thumbnail="${pageContext.request.contextPath}/uploads/projects/${projectData.images[0]}"
 		    userLimit="40000000"
 		    walletBalance="${myCash}"

--- a/src/main/webapp/resources/js/domain/admin/project_register.js
+++ b/src/main/webapp/resources/js/domain/admin/project_register.js
@@ -167,7 +167,10 @@ function insertProject() {
     ProjectApi.insert(data)
     .then(text => {
         if(text === "success") {
-            alert("등록되었습니다.");
+            alert("프로젝트가 등록되고 증권사 API 성공하였습니다.");
+            window.location.href = `${ctx}/admin/project/new`;
+        } else if(text === "api_fail"){
+        	alert("프로젝트가 등록되고 증권사 API 실패하였습니다.");
             window.location.href = `${ctx}/admin/project/new`;
         } else {
             const errorMsg = text;


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- 프로젝트 생성 후 토큰 발급 정보를 강황증권에 API로 전달합니다.
- 전체 성공, 부분 성공, 실패로 나누었습니다.
- 스케줄러 동작 시 나왔던 log를 삭제하였습니다.
- 청약 신청 - 청약 내역 DB에 insert 하였습니다.
- 강황증권에 API로 값을 전달하여 response를 얻어 조건에 맞게 처리하였습니다.
- 아직 사용자 ID를 get해도 에러가 나서 사용자 id는 처리하지 못하였습니다.

## 📝 변경 사항 (Key Changes)
- [x] project_register.js를 수정해서 조건에 맞는 알림이 나오도록 하였습니다.

## 📸 스크린샷 (Screenshots / Demos)
| Feature | Screenshot |
| :--- | :--- |
| DB insert&API 성공 | <img width="865" height="659" alt="image" src="https://github.com/user-attachments/assets/e0564e0c-9c28-4e64-a554-79ddf020bd0e" /> |
| 성공 시 강황 증권 DB | <img width="1574" height="172" alt="image" src="https://github.com/user-attachments/assets/9a762b09-5f54-4a8f-94de-3ba933735224" /> |
| DB성공, API 실패 | <img width="798" height="441" alt="image" src="https://github.com/user-attachments/assets/85504a35-ec04-4f48-8940-92a87a6c88ec" /> |
| 청약 신청 완료 | <img width="868" height="1275" alt="image" src="https://github.com/user-attachments/assets/b4d829a1-3634-4b2a-808b-20ca6790c192" /> |
| 청약 성공 DB | <img width="1488" height="38" alt="image" src="https://github.com/user-attachments/assets/7f9c1d61-6863-4ce1-83d6-5fb2a934889a" /> |
| 청약 신청 실패 | <img width="839" height="1279" alt="image" src="https://github.com/user-attachments/assets/e5b4f4d8-c604-4d5e-9978-8f1c5c4c76a4" /> |
| 청약 실패 DB | <img width="1578" height="86" alt="image" src="https://github.com/user-attachments/assets/14ab3d39-c42a-42a1-98c5-8e8f17d9ffa1" /> |



## 🔗 연관된 이슈 (Related Issues)
- Close # api 실패 시 재시도 테이블에 insert 하는 것은 추후 구현하겠습니다.

## 🧐 주요 리뷰 포인트 (Review Point)
- /api/projects/insert 한 개의 api에서 프로젝트 처리 후 성공하면 강황증권 api를 실행하도록 하였습니다.

## ✅ 최종 PR전 체크 리스트 (Checklist)
- [x] 코딩 컨벤션(Checkstyle)을 준수하였는가?
- [x] 불필요한 주석이나 시스템 로그(console.log, print)를 제거하였는가?
- [x] 변경 사항에 대한 테스트를 완료하였는가?
- [x] 관련 문서를 업데이트하였는가?