### PR TITLE
[FEAT] 마이페이지 거래내역 완료 + 탄소 자잘하게 수정

### DIFF
--- a/src/main/java/com/animalfarm/mlf/domain/mypage/MypageController.java
+++ b/src/main/java/com/animalfarm/mlf/domain/mypage/MypageController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.animalfarm.mlf.common.ApiResponseDTO;
 import com.animalfarm.mlf.domain.mypage.dto.CarbonHistoryDTO;
 import com.animalfarm.mlf.domain.mypage.dto.HoldingDTO;
+import com.animalfarm.mlf.domain.mypage.dto.MyTransactionHistDTO;
 import com.animalfarm.mlf.domain.mypage.dto.PasswordUpdateRequestDTO;
 import com.animalfarm.mlf.domain.mypage.dto.ProfileDTO;
 import com.animalfarm.mlf.domain.mypage.dto.ProfileUpdateRequestDTO;
@@ -26,6 +27,19 @@ public class MypageController {
 
 	@Autowired
 	private MypageService mypageService;
+
+	@GetMapping("/transaction-history")
+	public ResponseEntity<ApiResponseDTO<List<MyTransactionHistDTO>>> getTransactionHistory(
+		@RequestParam(value = "page", defaultValue = "1")
+		int page,
+		@RequestParam(value = "period", defaultValue = "0")
+		int period,
+		@RequestParam(value = "category", required = false)
+		String category) {
+
+		List<MyTransactionHistDTO> list = mypageService.getTransactionHistory(page, period, category);
+		return ResponseEntity.ok(new ApiResponseDTO<>("거래 내역 조회 성공", list));
+	}
 
 	// 탄소 구매 내역 조회
 	@GetMapping("/carbon-history")

--- a/src/main/java/com/animalfarm/mlf/domain/mypage/MypageViewController.java
+++ b/src/main/java/com/animalfarm/mlf/domain/mypage/MypageViewController.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 @RequestMapping("/mypage")
@@ -42,9 +43,14 @@ public class MypageViewController {
 	}
 
 	@GetMapping("/transaction-history")
-	public String transactionHistoryPage(Model model) {
+	public String transactionHistoryPage(
+		@RequestParam(defaultValue = "1")
+		int page,
+		Model model) {
+
 		model.addAttribute("contentPage", "/WEB-INF/views/mypage/transaction_history.jsp");
 		model.addAttribute("menu", "transaction");
+
 		return "layout";
 	}
 

--- a/src/main/java/com/animalfarm/mlf/domain/mypage/dto/MyTransactionHistDTO.java
+++ b/src/main/java/com/animalfarm/mlf/domain/mypage/dto/MyTransactionHistDTO.java
@@ -1,0 +1,21 @@
+package com.animalfarm.mlf.domain.mypage.dto;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MyTransactionHistDTO {
+
+	private OffsetDateTime createdAt; // 거래 시각
+	private String transactionType; // 거래 유형(BUY, SELL, PASS, FAIL, DIVIDEND, BURN)
+	private String tokenName; // 토큰 이름
+	private String tickerSymbol; // 종목 코드
+	private BigDecimal executedPrice; // 체결 가격
+	private BigDecimal executedVolume; // 체결 수량
+	private BigDecimal executedAmount; // 체결 총액
+	private BigDecimal balanceAfter; // 체결 후 잔액
+}

--- a/src/main/webapp/WEB-INF/tags/category_tab.tag
+++ b/src/main/webapp/WEB-INF/tags/category_tab.tag
@@ -3,6 +3,8 @@
 
 <%@ attribute name="items" type="java.util.List" required="true" %>
 <%@ attribute name="activeValue" type="java.lang.String" %>
+<%-- [수정 1] onClick 속성 정의 추가 (함수 이름을 문자열로 받음) --%>
+<%@ attribute name="onClick" type="java.lang.String" %>
 
 <div class="project-tabs">
     <c:forEach var="item" items="${items}" varStatus="status">

--- a/src/main/webapp/WEB-INF/tags/mypage/transaction_history_table.tag
+++ b/src/main/webapp/WEB-INF/tags/mypage/transaction_history_table.tag
@@ -5,6 +5,14 @@
 <%@ attribute name="transactionList" type="java.util.List" required="true"  %>
 
 <table class="transaction-table">
+    <colgroup>
+        <col width="180px" /> <%-- 거래일시 --%>
+        <col width="80px" />  <%-- 구분 --%>
+        <col width="*" />     <%-- 종목명 (나머지 공간 차지) --%>
+        <col width="120px" /> <%-- 체결단가 --%>
+        <col width="100px" /> <%-- 거래수량 --%>
+        <col width="200px" /> <%-- 거래금액/잔액 --%>
+    </colgroup>
     <thead>
         <tr>
             <th class="head-first th-date">거래일시</th>
@@ -21,6 +29,7 @@
                 <c:forEach var="tx" items="${transactionList}">
                     <tr>
                         <td class="t-date">
+                            <%-- 날짜와 시간이 한 줄에 나오도록 공백 처리 --%>
                             <fmt:formatDate value="${tx.transactionAt}" pattern="yyyy-MM-dd HH:mm"/>
                         </td>
                         <%-- 거래 타입별 클래스 지정 --%>
@@ -82,29 +91,65 @@
 
 <style>
 /* 거래 내역 테이블 */
-.transaction-table { width: 100%; table-layout: fixed; border-collapse: collapse; background: #fff; border-radius: var(--radius-l); overflow: hidden; box-shadow: var(--shadow); }
-.transaction-table th { background: var(--gray-50); padding: 20px 8px; text-align: left; color: var(--gray-500); font: var(--font-button-02); border-bottom: 1px solid #F1F1F1; box-sizing: border-box; }
-.head-first {padding-left: 24px !important;}
-.head-last {padding-right: 24px !important;}
-.th-date {width: 148px;}
-.th-type {width: 60px;}
-.th-price {width: 140px;}
-.th-amount {width: 110px}
-.transaction-table td { padding: 20px 8px; border-bottom: 1px solid #F1F1F1; vertical-align: middle; }
+.transaction-table { 
+    width: 100%; 
+    table-layout: fixed; /* 컬럼 너비 고정 */
+    border-collapse: collapse; 
+    background: #fff; 
+    border-radius: var(--radius-l); 
+    overflow: hidden; 
+    box-shadow: var(--shadow); 
+}
+
+/* 헤더 스타일 */
+.transaction-table th { 
+    background: var(--gray-50); 
+    padding: 20px 8px; 
+    text-align: left; 
+    color: var(--gray-500); 
+    font: var(--font-button-02); 
+    border-bottom: 1px solid #F1F1F1; 
+    box-sizing: border-box; 
+}
+
+/* 첫 번째, 마지막 컬럼 패딩 */
+.head-first { padding-left: 24px !important; }
+.head-last { padding-right: 24px !important; }
+
+/* 데이터 셀 스타일 */
+.transaction-table td { 
+    padding: 20px 8px; 
+    border-bottom: 1px solid #F1F1F1; 
+    vertical-align: middle; 
+}
 .transaction-table td:first-child { padding-left: 24px; }
 .transaction-table td:last-child { padding-right: 24px; }
 
-.t-date { font: var(--font-body-01); color: var(--gray-900);}
-.t-type { font: var(--font-body-03); text-align: center; }
+/* [수정] 날짜: 너비를 늘리고 줄바꿈 방지 */
+.t-date { 
+    font: var(--font-body-01); 
+    color: var(--gray-900);
+    white-space: nowrap; /* 시간 떨어짐 방지 */
+}
+
+/* [수정] 구분: 중앙 정렬 */
+.t-type { 
+    font: var(--font-body-03); 
+    text-align: center; 
+}
+
+/* 구분 색상 */
 .type-buy { color: var(--error); }    /* 매수 */
 .type-sell { color: var(--info); }   /* 매도 */
 .type-div { color: var(--gray-900); } /* 배당 */
 .type-sub { color: var(--green-600); }    /* 청약 */
 .type-ref { color: var(--gray-900); } /* 환불 */
 
-.t-name { font: var(--font-body-03); color: var(--gray-900); margin-bottom: 2px; }
+/* 종목명 */
+.t-name { font: var(--font-body-03); color: var(--gray-900); margin-bottom: 2px; font-weight: 600; }
 .t-code { font: var(--font-caption-01); color: var(--gray-400); text-transform: uppercase; }
 
-.t-amount { font: var(--font-body-03); text-align: right; }
+/* 금액 */
+.t-amount { font: var(--font-body-03); text-align: right; font-weight: 700; }
 .t-balance { font: var(--font-caption-01); color: var(--gray-400); text-align: right; margin-top: 4px; }
 </style>

--- a/src/main/webapp/WEB-INF/views/carbon/carbon_detail.jsp
+++ b/src/main/webapp/WEB-INF/views/carbon/carbon_detail.jsp
@@ -40,8 +40,7 @@
             </div>
         </div>
 
-        <%-- 프로젝트 보러가기 버튼 --%>
-        <a href="#" class="btn-view-project">프로젝트 보러가기</a>
+        <button type="button" id="btnGoProject" class="btn-view-project">프로젝트 보러가기</button>
     </main>
 
     <aside class="content-side">

--- a/src/main/webapp/WEB-INF/views/mypage/carbon_history.jsp
+++ b/src/main/webapp/WEB-INF/views/mypage/carbon_history.jsp
@@ -23,7 +23,7 @@
     
     	<div class="header-with-btn">
 	    	<t:section_header title="탄소 배출권 구매 내역" subtitle="회원님이 구매하신 탄소 배출권의 상세 내역을 확인하세요." />
-            <button class="btn-market" onclick="location.href='${pageContext.request.contextPath}/market'">마켓으로 이동 ❯</button>
+            <button class="btn-market" onclick="location.href='${pageContext.request.contextPath}/carbon/list'">마켓으로 이동 ❯</button>
     	</div>
     	
         <mp:carbon_history_table carbonList="${carbonList}"/>

--- a/src/main/webapp/WEB-INF/views/mypage/transaction_history.jsp
+++ b/src/main/webapp/WEB-INF/views/mypage/transaction_history.jsp
@@ -1,8 +1,29 @@
+<%@page import="java.util.ArrayList"%>
+<%@page import="java.util.HashMap"%>
+<%@page import="java.util.Map"%>
+<%@page import="java.util.List"%>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="t" tagdir="/WEB-INF/tags"%>
 <%@ taglib prefix="mp" tagdir="/WEB-INF/tags/mypage"%>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+
+<%
+    /* 상단 탭 데이터 생성 (value를 API 명세의 대분류 category 값으로 설정) */
+    List<Map<String, Object>> transactionTabs = new ArrayList<>();
+    
+    Map<String, Object> tab1 = new HashMap<>();
+    tab1.put("title", "토큰");
+    tab1.put("value", "TOKEN"); // 클릭 시 category=TOKEN 전송
+    transactionTabs.add(tab1);
+    
+    Map<String, Object> tab2 = new HashMap<>();
+    tab2.put("title", "프로젝트");
+    tab2.put("value", "PROJECT"); // 클릭 시 category=PROJECT 전송
+    transactionTabs.add(tab2);
+    
+    request.setAttribute("transactionTabs", transactionTabs);
+%>
 
 <link rel="stylesheet" href="${pageContext.request.contextPath}/resources/css/mypage.css">
 <style>
@@ -26,34 +47,217 @@
     <div class="content-wrapper">
     
     	<t:section_header title="거래 내역" subtitle="투자, 충전, 정산 등 모든 거래 기록을 확인하세요." />
-
+		<t:category_tab 
+            items="${transactionTabs}" 
+            activeValue="${empty param.category ? 'TOKEN' : param.category}"         
+        />
+		
         <div class="filter-container">
-	        <div class="filter-group">
-	            <t:menu_button label="전체보기" 
-	                       active="${empty param.projectStatus}" 
-	                       onClick=""/>
-	        	<t:menu_button label="청약중" 
-	                       active="${param.projectStatus == 'SUBSCRIPTION'}" 
-	                       onClick=""/>
-	        	<t:menu_button label="공고중" 
-	                       active="${param.projectStatus == 'ANNOUNCEMENT'}" 
-	                       onClick=""/>
-	        	<t:menu_button label="종료됨" 
-	                       active="${param.projectStatus == 'COMPLETED'}" 
-	                       onClick=""/>
-	        </div>
-            <select class="period-select">
-                <option>전체 기간</option>
-                <option>최근 1개월</option>
-                <option>최근 3개월</option>
-                <option>최근 6개월</option>
+	        <div id="filter-group-token" class="filter-group">
+                <t:menu_button label="전체보기" active="true" onClick="changeFilter('TOKEN', this)"/>
+                <t:menu_button label="매수" active="false" onClick="changeFilter('BUY', this)"/>
+                <t:menu_button label="매도" active="false" onClick="changeFilter('SELL', this)"/>
+            </div>
+
+            <div id="filter-group-project" class="filter-group" style="display: none;">
+                <t:menu_button label="전체보기" active="true" onClick="changeFilter('PROJECT', this)"/>
+                <t:menu_button label="당첨(청약)" active="false" onClick="changeFilter('PASS', this)"/>
+                <t:menu_button label="낙첨(환불)" active="false" onClick="changeFilter('FAIL', this)"/>
+                <t:menu_button label="배당" active="false" onClick="changeFilter('DIVIDEND', this)"/>
+                <t:menu_button label="소각" active="false" onClick="changeFilter('BURN', this)"/>
+            </div>
+            <select class="period-select" id="periodSelect" onchange="filterPeriod()">
+                <option value="0">전체 기간</option>
+                <option value="1">최근 1개월</option>
+                <option value="3">최근 3개월</option>
+                <option value="6">최근 6개월</option>
             </select>
         </div>
 
-        <mp:transaction_history_table transactionList="${transactionList }"/>
+        <div id="transactionTableContainer">
+            <%-- 초기 로딩 시 빈 리스트로 껍데기만 렌더링하고 JS로 채웁니다 --%>
+		    <mp:transaction_history_table transactionList="${emptyList}"/>
+		</div>
 		
-		<c:if test="${transactionList.length>0}">
-        	<button class="btn-more"  onclick="">+ 더보기</button>
-		</c:if>
+		<button class="btn-more" id="btnMore" onclick="loadMore()" style="display: none;">+ 더보기</button>
+		
     </div>
 </div>
+
+<script>
+// 전역 변수
+let currentPage = 1;
+// main 없이 category만 사용 (기본값: TOKEN)
+let currentCategory = 'TOKEN'; 
+let currentPeriod = 0;
+let currentTabType = 'TOKEN'; 
+
+document.addEventListener("DOMContentLoaded", function() {
+    loadTransactionHistory(false);
+});
+
+// 탭 변경
+function handleTabClick(value) {
+    if(currentTabType === value) return;
+
+ // 1. 데이터 변경
+    currentTabType = value;     
+    currentCategory = value;    
+    currentPage = 1;
+
+    // 2. [중요] UI 업데이트 (녹색 밑줄 이동)
+    // 태그 파일이 만들어낸 .tab-item 요소들을 찾아서 active 클래스를 직접 제어합니다.
+    const tabs = document.querySelectorAll('.tab-item');
+    tabs.forEach(tab => {
+        // 탭의 텍스트나 내부 구조를 통해 클릭된 탭인지 확인
+        // (가장 확실한 방법은 태그 파일의 onclick 문자열을 확인하는 것입니다)
+        const onclickAttr = tab.getAttribute('onclick');
+        if (onclickAttr && onclickAttr.includes("'" + value + "'")) {
+            tab.classList.add('active');
+        } else {
+            tab.classList.remove('active');
+        }
+    });
+
+    // 3. 하단 필터 그룹 교체 (토큰 <-> 프로젝트)
+    const tokenFilters = document.getElementById('filter-group-token');
+    const projectFilters = document.getElementById('filter-group-project');
+
+    if (currentTabType === 'TOKEN') {
+        tokenFilters.style.display = 'flex';
+        projectFilters.style.display = 'none';
+        resetActiveButton(tokenFilters);
+    } else {
+        tokenFilters.style.display = 'none';
+        projectFilters.style.display = 'flex';
+        resetActiveButton(projectFilters);
+    }
+    
+    // 4. 데이터 로드
+    loadTransactionHistory(false);
+}
+
+// 필터 변경
+function changeFilter(categoryValue, btnElement) {
+    if(currentCategory === categoryValue && currentPage === 1) return;
+
+    currentCategory = categoryValue;
+    currentPage = 1;
+
+    const parentGroup = btnElement.closest('.filter-group');
+    const buttons = parentGroup.querySelectorAll('button');
+    buttons.forEach(btn => btn.classList.remove('active'));
+    btnElement.classList.add('active');
+
+    loadTransactionHistory(false);
+}
+
+function resetActiveButton(groupElement) {
+    const buttons = groupElement.querySelectorAll('button');
+    buttons.forEach((btn, index) => {
+        if(index === 0) btn.classList.add('active');
+        else btn.classList.remove('active');
+    });
+}
+
+// 데이터 로드
+function loadTransactionHistory(isAppend) {
+    const token = localStorage.getItem("accessToken");
+  
+    
+    // API 호출 (category만 전송)
+   let url = ctx + "/api/mypage/transaction-history?page=" + currentPage + 
+        "&period=" + currentPeriod + 
+        "&category=" + currentCategory;
+
+    fetch(url, {
+        method: "GET",
+        headers: {
+            "Accept": "application/json",
+            "Authorization": "Bearer " + token
+        }
+    })
+    .then(res => {
+        if (!res.ok) throw new Error("데이터 로드 실패");
+        return res.json();
+    })
+    .then(data => {
+        const tbody = document.querySelector(".transaction-table tbody");
+        const btnMore = document.getElementById("btnMore");
+        if (!tbody) return;
+
+        const list = data.payload || [];
+
+        if (!isAppend) tbody.innerHTML = "";
+
+        if (list.length === 0 && !isAppend) {
+            tbody.innerHTML = '<tr><td colspan="6" style="text-align: center; padding: 60px; color: var(--gray-400);">거래 내역이 존재하지 않습니다.</td></tr>';
+            if(btnMore) btnMore.style.display = "none";
+            return;
+        }
+
+        let html = "";
+        const typeConfig = {
+            'BUY': { label: '매수', class: 'type-buy' },
+            'SELL': { label: '매도', class: 'type-sell' },
+            'PASS': { label: '청약', class: 'type-sub' },
+            'FAIL': { label: '환불', class: 'type-ref' },
+            'DIVIDEND': { label: '배당', class: 'type-div' },
+            'BURN': { label: '소각', class: 'type-div' }
+        };
+
+        list.forEach(tx => {
+            const config = typeConfig[tx.transactionType] || { label: tx.transactionType, class: '' };
+            
+            let timestamp = tx.createdAt;
+            if (typeof timestamp === 'number' && timestamp < 10000000000) {
+                timestamp = timestamp * 1000;
+            }
+            const date = new Date(timestamp);
+            const dateStr = date.getFullYear() + '-' + 
+                            String(date.getMonth() + 1).padStart(2, '0') + '-' + 
+                            String(date.getDate()).padStart(2, '0') + ' ' + 
+                            String(date.getHours()).padStart(2, '0') + ':' + 
+                            String(date.getMinutes()).padStart(2, '0');
+
+            html += `
+                <tr>
+                    <td class="t-date">\${dateStr}</td>
+                    <td class="t-type \${config.class}">\${config.label}</td>
+                    <td>
+                        <div class="t-name">\${tx.tokenName}</div>
+                        <div class="t-code">\${tx.tickerSymbol}</div>
+                    </td>
+                    <td style="text-align: right; font-weight: 700;">
+                        \${tx.executedPrice ? tx.executedPrice.toLocaleString() + ' 원' : '-'}
+                    </td>
+                    <td style="text-align: right; font-weight: 700;">
+                        \${tx.executedVolume ? (tx.executedVolume > 0 ? '+' : '') + tx.executedVolume.toLocaleString() + ' st' : '-'}
+                    </td>
+                    <td>
+                        <div class="t-amount">\${(tx.executedAmount > 0 ? '+' : '') + tx.executedAmount.toLocaleString()} 원</div>
+                        <div class="t-balance">\${tx.balanceAfter.toLocaleString()} 원</div>
+                    </td>
+                </tr>
+            `;
+        });
+        
+        if (isAppend) tbody.innerHTML += html;
+        else tbody.innerHTML = html;
+
+        if (btnMore) btnMore.style.display = (list.length < 10) ? "none" : "block";
+    })
+    .catch(err => console.error("Fetch Error:", err));
+}
+
+function filterPeriod() {
+    currentPeriod = document.querySelector(".period-select").value;
+    currentPage = 1;
+    loadTransactionHistory(false);
+}
+
+function loadMore() {
+    currentPage++;
+    loadTransactionHistory(true);
+}
+</script>

--- a/src/main/webapp/resources/js/domain/carbon/carbon_detail.js
+++ b/src/main/webapp/resources/js/domain/carbon/carbon_detail.js
@@ -49,6 +49,15 @@ function renderPage(data) {
 
     const info = data.carbonInfo;
     const benefit = data.userBenefit;
+    const projectId = info.projectId; // CarbonDTO의 프로젝트 ID 필드
+
+    // 버튼 요소를 찾아 클릭 시 해당 프로젝트 상세로 이동하게 설정
+    const btn = document.getElementById("btnGoProject");
+    if (btn && projectId) {
+        btn.onclick = function() {
+            location.href = ctx + "/project/" + projectId;
+        };
+    }
 
     // info(CarbonDTO)가 아니라 data(CarbonDetailDTO)에서 직접 꺼냅니다.
     const mainImg = document.getElementById("detailMainImg");


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- 마이페이지 거래내역 완료(토큰 쪽은 다 테스트했는데 프로젝트 쪽은 더미를 넣을 엄두가 안났습니다...) 
- 탄소 자잘하게 수정(상세페이지에서 프로젝트 상세페이지로 연결, 탄소거래내역에서 마켓으로 이동 연결) 

## 📸 스크린샷 (Screenshots / Demos)
| Feature | Screenshot |
| :--- | :--- |
| 거래내역 | <img width="1294" height="866" alt="image" src="https://github.com/user-attachments/assets/de8f9a97-26ef-4aef-bd66-81fb6c2bc398" /> |

## 🔗 연관된 이슈 (Related Issues)
- Close #89
