### PR TITLE
[FIX] kh-holdings API 주소 변경

### DIFF
--- a/src/main/java/com/animalfarm/mlf/domain/carbon/CarbonService.java
+++ b/src/main/java/com/animalfarm/mlf/domain/carbon/CarbonService.java
@@ -33,7 +33,7 @@ public class CarbonService {
 	private RestTemplate restTemplate;
 
 	// 강황증권 API 서버 주소
-	private final String GANGHWANG_API_URL = "http://54.167.85.125:9090/";
+	private final String GANGHWANG_API_URL = "https://kh-holdings.cloud/";
 
 	// ---------------------------------------------------------
 	// 1. 공통 유틸리티 메서드 (내부 전용)

--- a/src/main/java/com/animalfarm/mlf/domain/mypage/MypageService.java
+++ b/src/main/java/com/animalfarm/mlf/domain/mypage/MypageService.java
@@ -32,7 +32,7 @@ public class MypageService {
 	private RestTemplate restTemplate;
 
 	// 강황증권 API 서버 주소
-	private final String GANGHWANG_API_URL = "http://54.167.85.125:9090/";
+	private final String GANGHWANG_API_URL = "https://kh-holdings.cloud/";
 
 	// ---------------------------------------------------------
 	// 탄소 구매 내역 조회

--- a/src/main/webapp/resources/js/domain/token/token_api.js
+++ b/src/main/webapp/resources/js/domain/token/token_api.js
@@ -1,7 +1,7 @@
 // api/token_api.js
 import { http } from "../../api/http_client.js";
 
-const BASE_URL = 'https://54.167.85.125:9090';
+const BASE_URL = 'https://kh-holdings.cloud';
 
 export const TokenApi = {
     WS_CONN: `${BASE_URL}/ws-stomp`,


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- kh-holdings API 주소 변경
- 

## 📝 변경 사항 (Key Changes)
- [ ] EC2와 RDS가 각각 버지니아, 시드니에서 서울로 변경됨에 따라 59.-.-.- => kh-holdings.cloud로 변경됐습니다
- [ ] 

## 📸 스크린샷 (Screenshots / Demos)
| Feature | Screenshot |
| :--- | :--- |
| 기능명 | 사진첨부 |

## 🔗 연관된 이슈 (Related Issues)
- Close #

## 🧐 주요 리뷰 포인트 (Review Point)
- 

## ✅ 최종 PR전 체크 리스트 (Checklist)
- [√] 코딩 컨벤션(Checkstyle)을 준수하였는가?
- [ ] 불필요한 주석이나 시스템 로그(console.log, print)를 제거하였는가?
- [ ] 변경 사항에 대한 테스트를 완료하였는가?
- [ ] 관련 문서를 업데이트하였는가?