### PR TITLE
[FEAT] 회원가입 후 로그인 페이지 404, 헤더 로그인 후 이름 변경 안됨 수정

### DIFF
--- a/src/main/java/com/animalfarm/mlf/domain/user/controller/UserDetailController.java
+++ b/src/main/java/com/animalfarm/mlf/domain/user/controller/UserDetailController.java
@@ -1,14 +1,11 @@
 package com.animalfarm.mlf.domain.user.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.animalfarm.mlf.common.security.SecurityUtil;
-import com.animalfarm.mlf.domain.user.dto.UserDTO;
 import com.animalfarm.mlf.domain.user.service.UserService;
 
 @RestController
@@ -17,22 +14,10 @@ public class UserDetailController {
 
 	@Autowired
 	private UserService userService;
-	
-	@GetMapping("/me")
-    public ResponseEntity<Object> getCurrentUserInfo() {
-        try {
-            Long userId = SecurityUtil.getCurrentUserId();
-            if (userId == null) {
-                // 토큰이 없거나 유효하지 않은 경우 401 반환
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인이 필요합니다.");
-            }
-            
-            // 유저 정보 조회 (address 포함)
-            UserDTO user = userService.getUserById(userId);
-            return ResponseEntity.ok(user);
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
-        }
-    }
-	
+
+	@GetMapping(value = "/me/name", produces = "text/plain; charset=UTF-8")
+	public ResponseEntity<String> getMyName() {
+		return ResponseEntity.ok(userService.getMyName());
+	}
+
 }

--- a/src/main/java/com/animalfarm/mlf/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/animalfarm/mlf/domain/user/repository/UserRepository.java
@@ -3,12 +3,11 @@ package com.animalfarm.mlf.domain.user.repository;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
-import com.animalfarm.mlf.domain.user.dto.UserCertificateLinkDTO;
 import com.animalfarm.mlf.domain.user.dto.UserDTO;
 
 @Mapper
 public interface UserRepository {
-	
+
 	UserDTO findByEmail(String email);
 
 	int insertUser(UserDTO user);
@@ -24,4 +23,7 @@ public interface UserRepository {
 	UserDTO getUserById(Long userId);
 
 	Long selectUserIdByUclId(Long walletId);
+
+	String selectUserNameById(@Param("userId")
+	Long userId);
 }

--- a/src/main/java/com/animalfarm/mlf/domain/user/service/UserService.java
+++ b/src/main/java/com/animalfarm/mlf/domain/user/service/UserService.java
@@ -1,9 +1,11 @@
 package com.animalfarm.mlf.domain.user.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import com.animalfarm.mlf.common.RedisUtil;
 import com.animalfarm.mlf.common.security.SecurityUtil;
@@ -90,8 +92,18 @@ public class UserService {
 		userRepository.updateAddress(address, userId);
 	}
 
-	public UserDTO getUserById(Long userId) {
-		return userRepository.getUserById(userId);
+	public String getMyName() {
+		Long userId = SecurityUtil.getCurrentUserId();
+		if (userId == null) {
+			throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
+		}
+
+		String name = userRepository.selectUserNameById(userId);
+		if (name == null || name.isBlank()) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자 이름이 없습니다.");
+		}
+
+		return name;
 	}
 
 }

--- a/src/main/resources/mybatis/mappers/UserMapper.xml
+++ b/src/main/resources/mybatis/mappers/UserMapper.xml
@@ -53,4 +53,9 @@
     	WHERE ucl_id = #{uclId}
     </select>
 
+	<select id="selectUserNameById" parameterType="long" resultType="string">
+	  SELECT user_name
+	  FROM users
+	  WHERE user_id = #{userId}
+	</select>
 </mapper>

--- a/src/main/webapp/WEB-INF/views/auth/signup.jsp
+++ b/src/main/webapp/WEB-INF/views/auth/signup.jsp
@@ -314,7 +314,7 @@
             <span style="font-size:64px;display:block;margin-bottom:24px;color:var(--green-600);"><i class="fa-solid fa-leaf"></i></span>
             <h2 class="auth-title">가입을 축하드립니다!</h2>
             <p class="auth-desc">로그인 페이지로 이동하여 서비스를 이용해보세요.</p>
-            <button class="btn-main" type="button" onclick="location.href='<%=request.getContextPath()%>/users/login'">로그인하러 가기</button>
+            <button class="btn-main" type="button" onclick="location.href='<%=request.getContextPath()%>/auth/login'">로그인하러 가기</button>
           </div>
 
         </div>


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- 로그인을 해도 로그인 사용자의 이름이 아닌 마리팜님 이 나오는 에러를 사용자의 이름이 나오게 수정.
- 회원가입 완료하면 로그인 주소 매핑이 잘못됐음. 이를 올바른 주소로 매핑.

## 📸 스크린샷 (Screenshots / Demos)
| Feature | Screenshot |
| :--- | :--- |
| 로그인 시 사용자의 이름 | <img width="213" height="56" alt="image" src="https://github.com/user-attachments/assets/0d3d1869-9351-43be-aabf-34e50e653cca" /> |

## ✅ 최종 PR전 체크 리스트 (Checklist)
- [x] 코딩 컨벤션(Checkstyle)을 준수하였는가?
- [x] 불필요한 주석이나 시스템 로그(console.log, print)를 제거하였는가?
- [x] 변경 사항에 대한 테스트를 완료하였는가?
- [x] 관련 문서를 업데이트하였는가?