### PR TITLE
[FIX] 서버 에러 응답 메세지 반환하도록 수정

### DIFF
--- a/src/main/java/com/animalfarm/mlf/common/http/GlobalExceptionHandler.java
+++ b/src/main/java/com/animalfarm/mlf/common/http/GlobalExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.animalfarm.mlf.common.http;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(RuntimeException.class)
+	public ResponseEntity<ApiResponse<Void>> handleRuntimeException(RuntimeException e) {
+		// e.getMessage()에는 우리가 깎아놓은 "보유 토큰이 부족합니다"가 들어있음
+		return ResponseEntity
+			.status(HttpStatus.INTERNAL_SERVER_ERROR) // 500
+			.body(ApiResponse.message(e.getMessage())); // JSON으로 응답
+	}
+}

--- a/src/main/webapp/WEB-INF/views/token/token_detail.jsp
+++ b/src/main/webapp/WEB-INF/views/token/token_detail.jsp
@@ -161,6 +161,7 @@
                 <div id="order-tab" class="scroll active">
                     <table class="hoga-table">
                         <thead>
+                        </thead>
                         <tbody id="order-hist-body">
                         </tbody>
                     </table>

--- a/src/main/webapp/resources/css/token_detail.css
+++ b/src/main/webapp/resources/css/token_detail.css
@@ -115,8 +115,11 @@
 .trade-dir { color: var(--gray-400); }
 
 /* 호가 컬러 */
-.hoga-sell { color: var(--error); font-weight: 600; }
-.hoga-buy { color: var(--info); font-weight: 600; }
+.hoga-sell { color: var(--info); font-weight: 600; }
+.hoga-buy { color: var(--error); font-weight: 600; }
+
+/* 호가 한 행 */
+.order-hist-row { cursor: pointer; }
 
 /* 트레이딩뷰 로고 제거 */
 .token-chart a { display: none !important; }

--- a/src/main/webapp/resources/js/domain/token/token_detail.js
+++ b/src/main/webapp/resources/js/domain/token/token_detail.js
@@ -427,7 +427,7 @@ async function handleOrder(event, side) {
             ToastManager.show("주문이 완료되었습니다.");
         }
     } catch (e) {
-        ToastManager.show("주문에 실패하였습니다.")
+        ToastManager.show(e.message);
         console.error("주문 실패: ", e);
     }
 };
@@ -702,7 +702,7 @@ function createOrderRowHtml(item, type) {
     const formattedVolume = Number(item.totalVolume).toFixed(4);
 
     return `
-        <tr>
+        <tr class="order-hist-row">
             <td class="trade-dir ${dirClass}">${sideText}</td>
             <td class="${sideClass}" style="text-align: right;">${formattedPrice}</td>
             <td style="text-align: right;">${formattedVolume}</td>


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- ExceptionHandler 추가
- 서버가 보낸 에러 메세지 추출
- http_client에서 응답 에러 시 토스트 띄워주는 거 제거
- 호가/체결창 매수/매도 색 바꾸기

## 📝 변경 사항 (Key Changes)
- [ ] ExternalApiUtil
- [ ] GlobalExceptionHandler
- [ ] http_client

## 📸 스크린샷 (Screenshots / Demos)
| Feature | Screenshot |
| :--- | :--- |
| 기능명 | 사진첨부 |

## 🔗 연관된 이슈 (Related Issues)
- Close #

## 🧐 주요 리뷰 포인트 (Review Point)
- 

## ✅ 최종 PR전 체크 리스트 (Checklist)
- [√] 코딩 컨벤션(Checkstyle)을 준수하였는가?
- [ ] 불필요한 주석이나 시스템 로그(console.log, print)를 제거하였는가?
- [ ] 변경 사항에 대한 테스트를 완료하였는가?
- [ ] 관련 문서를 업데이트하였는가?