### PR TITLE
[FIX] 마이페이지 > 거래내역 > 프로젝트 내 환불 내역도 토큰 정보 가져오도록 수정

### DIFF
--- a/src/main/java/com/animalfarm/mlf/domain/mypage/MypageService.java
+++ b/src/main/java/com/animalfarm/mlf/domain/mypage/MypageService.java
@@ -85,7 +85,7 @@ public class MypageService {
 				List<MyTransactionHistDTO> originalList = response.getBody().getPayload();
 
 				// DB 조회가 필요한 유형 정의
-				Set<String> targetTypes = Set.of("PASS", "FAIL", "DIVIDEND", "BURN");
+				Set<String> targetTypes = Set.of("PASS", "FAIL", "BURN");
 
 				// DB 조회가 필요한 거래 번호만 필터링하여 리스트 생성
 				List<Long> targetIds = originalList.stream()

--- a/src/main/resources/mybatis/mappers/MypageMapper.xml
+++ b/src/main/resources/mybatis/mappers/MypageMapper.xml
@@ -181,16 +181,30 @@
 	<!-- 거래 번호로 토큰 이름 및 종목 코드 조회 -->
 	<select id="findTokenInfoByTxId" resultType="com.animalfarm.mlf.domain.mypage.dto.TokenInfoDTO">
 		SELECT
-			tl.external_ref_id AS externalRefId,
+			th.external_ref_id AS externalRefId,
 			t.token_name AS tokenName,
 			t.ticker_symbol AS tickerSymbol
-		FROM token_ledger tl
-		JOIN tokens t
-			ON tl.token_id = t.token_id
-		WHERE tl.external_ref_id IN
-		<foreach item="id" collection="txIdList" open="(" separator="," close=")">
-			#{id}
-		</foreach>
+		FROM (
+			SELECT external_ref_id, token_id
+			FROM token_ledger
+			WHERE external_ref_id IN
+			<foreach item="id" collection="txIdList" open="(" separator="," close=")">
+				#{id}
+			</foreach>
+
+			UNION ALL
+
+			SELECT
+			r.external_ref_id::bigint AS externalRefId,
+			tt.token_id
+			FROM refunds r
+			INNER JOIN tokens tt ON r.project_id = tt.project_id
+			WHERE r.external_ref_id IN
+			<foreach item="id" collection="txIdList" open="(" separator="," close=")">
+				#{id}::text
+			</foreach>
+		) th
+		JOIN tokens t ON th.token_id = t.token_id
 	</select>
 
 </mapper>

--- a/src/main/webapp/WEB-INF/tags/mypage/transaction_history_table.tag
+++ b/src/main/webapp/WEB-INF/tags/mypage/transaction_history_table.tag
@@ -10,7 +10,7 @@
         <col width="80px" />  <%-- 구분 --%>
         <col width="*" />     <%-- 종목명 (나머지 공간 차지) --%>
         <col width="120px" /> <%-- 체결단가 --%>
-        <col width="100px" /> <%-- 거래수량 --%>
+        <col width="120px" /> <%-- 거래수량 --%>
         <col width="200px" /> <%-- 거래금액/잔액 --%>
     </colgroup>
     <thead>


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- 배당(DIVIDEND)의 토큰 정보는 강황증권에서 반환하므로 로직에서 제거
- 환불내역의 토큰 정보를 조회하기 위해 refunds 테이블 합치기(union)
- 거래수량 필드 너비 넓히기

## 📝 변경 사항 (Key Changes)
- [ ] MypageService
- [ ] MypageMapper
- [ ] transaction_history_table

## 📸 스크린샷 (Screenshots / Demos)
| Feature | Screenshot |
| :--- | :--- |
| 기능명 | 사진첨부 |

## 🔗 연관된 이슈 (Related Issues)
- Close #

## 🧐 주요 리뷰 포인트 (Review Point)
- 

## ✅ 최종 PR전 체크 리스트 (Checklist)
- [√] 코딩 컨벤션(Checkstyle)을 준수하였는가?
- [ ] 불필요한 주석이나 시스템 로그(console.log, print)를 제거하였는가?
- [ ] 변경 사항에 대한 테스트를 완료하였는가?
- [ ] 관련 문서를 업데이트하였는가?